### PR TITLE
Change state and time duration

### DIFF
--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -53,9 +53,9 @@ TIMEOUT = 10  # Request Timeout in seconds
 
 # TIMERS & ALARMS ATTRIBUTE NAMES
 FIRE_TIME = "fire_time"
-DATETIME_UTC = "date_time_utc"
 LOCAL_TIME = "local_time"
-TIME_LEFT = "time_left"
+LOCAL_TIME_ISO = "local_time_iso"
+DURATION = "duration"
 ORIGINAL_DURATION = "original_duration"
 
 # TIMESTRINGS

--- a/custom_components/ha-google-home/sensor.py
+++ b/custom_components/ha-google-home/sensor.py
@@ -2,13 +2,12 @@
 import logging
 
 from homeassistant.const import STATE_OFF
+from homeassistant.const import STATE_ON
 
 from .const import DOMAIN
 from .const import LABEL_ALARMS
 from .const import LABEL_TIMERS
 from .const import LABEL_TOKEN
-from .const import LOCAL_TIME
-from .const import TIME_LEFT
 from .entity import GoogleHomeAlarmEntity
 from .entity import GoogleHomeTimersEntity
 from .entity import GoogleHomeTokenEntity
@@ -68,7 +67,7 @@ class GoogleHomeAlarmSensor(GoogleHomeAlarmEntity):
     @property
     def state(self):
         alarms = self._get_alarms_data()
-        state = alarms[0][LOCAL_TIME] if alarms else STATE_OFF
+        state = STATE_ON if len(alarms) else STATE_OFF
         return state
 
     @property
@@ -100,7 +99,7 @@ class GoogleHomeTimerSensor(GoogleHomeTimersEntity):
     @property
     def state(self):
         timers = self._get_timers_data()
-        return timers[0][TIME_LEFT] if timers else STATE_OFF
+        return STATE_ON if len(timers) else STATE_OFF
 
     @property
     def device_state_attributes(self):

--- a/custom_components/ha-google-home/sensor.py
+++ b/custom_components/ha-google-home/sensor.py
@@ -45,7 +45,10 @@ class GoogleHomeTokenSensor(GoogleHomeTokenEntity):
         """Initialize the sensor."""
         super().__init__(coordinator, entry)
         self._name = device_name
-        self._state = local_auth_token
+
+    @property
+    def state(self):
+        return self.coordinator.data[self._name][LABEL_TOKEN]
 
     @property
     def device_state_attributes(self):

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -5,11 +5,11 @@ from homeassistant.util.dt import as_local
 from homeassistant.util.dt import utc_from_timestamp
 
 from .const import DATETIME_STR_FORMAT
-from .const import DATETIME_UTC
+from .const import DURATION
 from .const import FIRE_TIME
 from .const import LOCAL_TIME
+from .const import LOCAL_TIME_ISO
 from .const import ORIGINAL_DURATION
-from .const import TIME_LEFT
 
 
 def convert_from_ms_to_s(timestamp):
@@ -23,9 +23,10 @@ def format_timer_information(timer_dict):
     duration = convert_from_ms_to_s(timer_dict[ORIGINAL_DURATION])
 
     dt_utc = utc_from_timestamp(timer[FIRE_TIME])
-    timer[DATETIME_UTC] = dt_utc.strftime(DATETIME_STR_FORMAT)
-    timer[LOCAL_TIME] = as_local(dt_utc).strftime(DATETIME_STR_FORMAT)
-    timer[TIME_LEFT] = str(timedelta(seconds=duration))
+    dt_local = as_local(dt_utc)
+    timer[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
+    timer[LOCAL_TIME_ISO] = dt_local.isoformat()
+    timer[DURATION] = str(timedelta(seconds=duration))
     return timer
 
 
@@ -35,6 +36,7 @@ def format_alarm_information(alarm_dict):
     alarm[FIRE_TIME] = convert_from_ms_to_s(alarm_dict[FIRE_TIME])
 
     dt_utc = utc_from_timestamp(alarm[FIRE_TIME])
-    alarm[DATETIME_UTC] = dt_utc.strftime(DATETIME_STR_FORMAT)
-    alarm[LOCAL_TIME] = as_local(dt_utc).strftime(DATETIME_STR_FORMAT)
+    dt_local = as_local(dt_utc)
+    alarm[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
+    alarm[LOCAL_TIME_ISO] = dt_local.isoformat()
     return alarm


### PR DESCRIPTION
- Changing timer and alarm states to on/off correspondingly if there are any values set.
- Adding `local_time_iso` key to timer and alarm sensors for easier automation

Closes #50
Closes #52 