### PR TITLE
Adding multiple alarm/timer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,34 @@ This component will set up the following platforms:
 | `sensor` | `sensor.living_room_alarms` | Sensor with alarms from the device                        |
 | `sensor` | `sensor.living_room_token`  | Sensor with the local authentication token for the device |
 
+### Timers
+You can have multiple timers on your Google Home device. The Home Assistant
+timers sensor will represent all of them in the state attributes as a list "timers".
+Each of timers has the following keys:
+
+| Key | Value type               | Description                                               |
+| -------- | --------------------------- | --------------------------------------------------------- |
+| `id` | Google Home corresponding ID | Used to delete/modify timer                        |
+| `fire_time` | Seconds | Raw value coming from Google Home device until the timer goes off  |
+| `local_time` | Time  | Time when the timer goes off, in respect to the Home Assistant's timezone |
+| `local_time_iso` | Time in ISO 8601 standard  | Useful for automations|
+| `duration` | Seconds  | Timer duration in seconds|
+
+
+### Alarms
+You can have multiple alarms on your Google Home device. The Home Assistant
+alarms sensor will represent all of them in the state attributes as a list
+"alarms".
+Each of alarms has the following keys:
+
+| Key | Value type               | Description                                               |
+| -------- | --------------------------- | --------------------------------------------------------- |
+| `id` | Google Home corresponding ID | Used to delete/modify alarm                        |
+| `fire_time` | Seconds | Raw value coming from Google Home device until the alarm goes off  |
+| `local_time` | Time  | Time when the alarm goes off, in respect to the Home Assistant's timezone |
+| `local_time_iso` | Time in ISO 8601 standard  | Useful for automations|
+| `recurrence` | List of integers  | Days of the week when the alarm will go off.  Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
+
 ## Getting Started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -77,32 +77,33 @@ This component will set up the following platforms:
 | `sensor` | `sensor.living_room_token`  | Sensor with the local authentication token for the device |
 
 ### Timers
+
 You can have multiple timers on your Google Home device. The Home Assistant
 timers sensor will represent all of them in the state attributes as a list "timers".
 Each of timers has the following keys:
 
-| Key | Value type               | Description                                               |
-| -------- | --------------------------- | --------------------------------------------------------- |
-| `id` | Google Home corresponding ID | Used to delete/modify timer                        |
-| `fire_time` | Seconds | Raw value coming from Google Home device until the timer goes off  |
-| `local_time` | Time  | Time when the timer goes off, in respect to the Home Assistant's timezone |
-| `local_time_iso` | Time in ISO 8601 standard  | Useful for automations|
-| `duration` | Seconds  | Timer duration in seconds|
-
+| Key              | Value type                   | Description                                                               |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `id`             | Google Home corresponding ID | Used to delete/modify timer                                               |
+| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off         |
+| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
+| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
+| `duration`       | Seconds                      | Timer duration in seconds                                                 |
 
 ### Alarms
+
 You can have multiple alarms on your Google Home device. The Home Assistant
 alarms sensor will represent all of them in the state attributes as a list
 "alarms".
 Each of alarms has the following keys:
 
-| Key | Value type               | Description                                               |
-| -------- | --------------------------- | --------------------------------------------------------- |
-| `id` | Google Home corresponding ID | Used to delete/modify alarm                        |
-| `fire_time` | Seconds | Raw value coming from Google Home device until the alarm goes off  |
-| `local_time` | Time  | Time when the alarm goes off, in respect to the Home Assistant's timezone |
-| `local_time_iso` | Time in ISO 8601 standard  | Useful for automations|
-| `recurrence` | List of integers  | Days of the week when the alarm will go off.  Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
+| Key              | Value type                   | Description                                                                                                                                                                                             |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`             | Google Home corresponding ID | Used to delete/modify alarm                                                                                                                                                                             |
+| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the alarm goes off                                                                                                                                       |
+| `local_time`     | Time                         | Time when the alarm goes off, in respect to the Home Assistant's timezone                                                                                                                               |
+| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                                                                                                                                                  |
+| `recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
 
 ## Getting Started
 

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -52,6 +52,8 @@ HEADERS = {
 TIMEOUT = 10  # Request Timeout in seconds
 
 # TIMERS & ALARMS ATTRIBUTE NAMES
+ID = "id"
+RECURRENCE = "recurrence"
 FIRE_TIME = "fire_time"
 LOCAL_TIME = "local_time"
 LOCAL_TIME_ISO = "local_time_iso"

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -69,7 +69,7 @@ API_RETURNED_UNKNOWN = "API returned unknown json structure"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL = 15
+UPDATE_INTERVAL = 60 * 5  # every 5 minutes
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM = "alarm"

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -69,7 +69,7 @@ API_RETURNED_UNKNOWN = "API returned unknown json structure"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL = 60 * 5  # every 5 minutes
+UPDATE_INTERVAL = 60 * 1  # every minute
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM = "alarm"

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -6,12 +6,12 @@ from homeassistant.util.dt import utc_from_timestamp
 
 from .const import DATETIME_STR_FORMAT
 from .const import DURATION
-from .const import RECURRENCE
-from .const import ID
 from .const import FIRE_TIME
+from .const import ID
 from .const import LOCAL_TIME
 from .const import LOCAL_TIME_ISO
 from .const import ORIGINAL_DURATION
+from .const import RECURRENCE
 
 
 def convert_from_ms_to_s(timestamp):

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -6,6 +6,8 @@ from homeassistant.util.dt import utc_from_timestamp
 
 from .const import DATETIME_STR_FORMAT
 from .const import DURATION
+from .const import RECURRENCE
+from .const import ID
 from .const import FIRE_TIME
 from .const import LOCAL_TIME
 from .const import LOCAL_TIME_ISO
@@ -24,6 +26,7 @@ def format_timer_information(timer_dict):
 
     dt_utc = utc_from_timestamp(timer[FIRE_TIME])
     dt_local = as_local(dt_utc)
+    timer[ID] = timer_dict[ID]
     timer[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     timer[LOCAL_TIME_ISO] = dt_local.isoformat()
     timer[DURATION] = str(timedelta(seconds=duration))
@@ -37,6 +40,8 @@ def format_alarm_information(alarm_dict):
 
     dt_utc = utc_from_timestamp(alarm[FIRE_TIME])
     dt_local = as_local(dt_utc)
+    alarm[ID] = alarm_dict[ID]
+    alarm[RECURRENCE] = alarm_dict[RECURRENCE]
     alarm[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     alarm[LOCAL_TIME_ISO] = dt_local.isoformat()
     return alarm


### PR DESCRIPTION
This is very basic support for multiple alarms and timers.
Also adding `id` fields to the instances that we will need when implementing alarm/timer manipulations like delete/modify etc.

Closes #25 

Example of alamrs
![image](https://user-images.githubusercontent.com/10655107/110121484-b9d60000-7dbe-11eb-8ffe-b057020bf33f.png)

Example of timers
![image](https://user-images.githubusercontent.com/10655107/110121533-ca867600-7dbe-11eb-89d4-8bdabf94f5ec.png)
