### PR TITLE
401 error handling and caching google devices

### DIFF
--- a/custom_components/ha-google-home/__init__.py
+++ b/custom_components/ha-google-home/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass,
         _LOGGER,
         name=SENSOR,
-        update_method=lambda: glocaltokens_client.update_google_devices_information(),
+        update_method=glocaltokens_client.update_google_devices_information,
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
 

--- a/custom_components/ha-google-home/__init__.py
+++ b/custom_components/ha-google-home/__init__.py
@@ -47,18 +47,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     session = async_get_clientsession(hass, verify_ssl=False)
 
+    zeroconf_instance = await zeroconf.async_get_instance(hass)
     glocaltokens_client = GlocaltokensApiClient(
-        hass, username, password, session, android_id
+        hass, username, password, session, android_id, zeroconf_instance
     )
 
-    zeroconf_instance = await zeroconf.async_get_instance(hass)
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=SENSOR,
-        update_method=lambda: glocaltokens_client.get_google_devices_information(
-            zeroconf_instance
-        ),
+        update_method=lambda: glocaltokens_client.update_google_devices_information(),
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
 

--- a/custom_components/ha-google-home/api.py
+++ b/custom_components/ha-google-home/api.py
@@ -130,7 +130,7 @@ class GlocaltokensApiClient:
                 )
         return resp
 
-    async def update_google_devices_information(self, zeroconf_instance):
+    async def update_google_devices_information(self):
         """Retrieves devices from google home devices"""
 
         _LOGGER.debug("Fetching sensor data...")
@@ -138,7 +138,7 @@ class GlocaltokensApiClient:
         offline_devices = []
         coordinator_data = {}
 
-        for device in self.get_google_devices():
+        for device in await self.get_google_devices():
             timers = []
             alarms = []
 

--- a/custom_components/ha-google-home/api.py
+++ b/custom_components/ha-google-home/api.py
@@ -164,7 +164,7 @@ class GlocaltokensApiClient:
             *[
                 self.get_alarms_and_timers(device)
                 for device in devices
-                if (device.ip and device.hardware in SUPPORTED_HARDWARE_LIST)
+                if device.ip and device.hardware in SUPPORTED_HARDWARE_LIST
             ]
         )
 

--- a/custom_components/ha-google-home/config_flow.py
+++ b/custom_components/ha-google-home/config_flow.py
@@ -40,11 +40,12 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             username = user_input[CONF_USERNAME]
             session = async_create_clientsession(self.hass)
             client = GlocaltokensApiClient(
-                self.hass,
-                user_input[CONF_USERNAME],
-                user_input[CONF_PASSWORD],
-                session,
-                None,
+                hass=self.hass,
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+                session=session,
+                android_id=None,
+                zeroconf_instance=None,
             )
             valid, master_token = await self._test_credentials(client)
             if valid:

--- a/custom_components/ha-google-home/config_flow.py
+++ b/custom_components/ha-google-home/config_flow.py
@@ -44,8 +44,6 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 username=user_input[CONF_USERNAME],
                 password=user_input[CONF_PASSWORD],
                 session=session,
-                android_id=None,
-                zeroconf_instance=None,
             )
             valid, master_token = await self._test_credentials(client)
             if valid:

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -41,6 +41,7 @@ SUPPORTED_HARDWARE_LIST = [
     "Google Home Hub",
     "Google Home Max",
     "Google Home Mini",
+    "Google Home",
     "Google Nest Mini",
     "Nest Audio",
     "Nest Hub Max",

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -70,7 +70,7 @@ API_RETURNED_UNKNOWN = "API returned unknown json structure"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL = 60 * 1  # every minute
+UPDATE_INTERVAL = 15 # sec
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM = "alarm"

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -70,7 +70,7 @@ API_RETURNED_UNKNOWN = "API returned unknown json structure"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL = 15 # sec
+UPDATE_INTERVAL = 15  # sec
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM = "alarm"

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -5,7 +5,7 @@ from homeassistant.util.dt import DATE_STR_FORMAT
 NAME = "Google-Home community driven integration"
 DOMAIN = "ha-google-home"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.4"
+VERSION = "v1.0.0"
 MANUFACTURER = "ha-google-home"
 
 ATTRIBUTION = "json"
@@ -35,6 +35,18 @@ DEFAULT_NAME = "HA-Google-Home"
 LABEL_ALARMS = "alarms"
 LABEL_TIMERS = "timers"
 LABEL_TOKEN = "token"
+
+# Supported Google Home devices
+SUPPORTED_HARDWARE_LIST = [
+    "Google Home Hub",
+    "Google Home Max",
+    "Google Home Mini",
+    "Google Nest Mini",
+    "Nest Audio",
+    "Nest Hub Max",
+    "Nest Hub",
+    "Nest Mini",
+]
 
 # DEVICE PORT
 PORT = 8443
@@ -70,7 +82,7 @@ API_RETURNED_UNKNOWN = "API returned unknown json structure"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL = 15  # sec
+UPDATE_INTERVAL = 10  # sec
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM = "alarm"

--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -38,10 +38,10 @@ LABEL_TOKEN = "token"
 
 # Supported Google Home devices
 SUPPORTED_HARDWARE_LIST = [
+    "Google Home",
     "Google Home Hub",
     "Google Home Max",
     "Google Home Mini",
-    "Google Home",
     "Google Nest Mini",
     "Nest Audio",
     "Nest Hub Max",

--- a/custom_components/ha-google-home/manifest.json
+++ b/custom_components/ha-google-home/manifest.json
@@ -2,7 +2,7 @@
   "after_dependencies": ["cloud", "http", "zeroconf"],
   "codeowners": ["@leikoilja", "@DurgNomis-drol", "@ArnyminerZ"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["rest"],
   "documentation": "https://github.com/leikoilja/ha-google-home",
   "domain": "ha-google-home",
   "issue_tracker": "https://github.com/leikoilja/ha-google-home/issues",

--- a/custom_components/ha-google-home/manifest.json
+++ b/custom_components/ha-google-home/manifest.json
@@ -2,7 +2,7 @@
   "after_dependencies": ["cloud", "http", "zeroconf"],
   "codeowners": ["@leikoilja", "@DurgNomis-drol", "@ArnyminerZ"],
   "config_flow": true,
-  "dependencies": ["rest"],
+  "dependencies": [],
   "documentation": "https://github.com/leikoilja/ha-google-home",
   "domain": "ha-google-home",
   "issue_tracker": "https://github.com/leikoilja/ha-google-home/issues",


### PR DESCRIPTION
- Adding google home device caching on the api class
- Adding error handling when the local auth token expires and the response to google home returns 401 
- Making sensor update rate back 15 sec

Closes #60 and #61 

With these changes, a new fresh homegraph request-response cycle takes about 20 seconds(should only happen 1-2 per day) but all the subsequent api calls to the devices themselves take about 0.2 sec