### PR TITLE
Parse labels to timers and alarms

### DIFF
--- a/custom_components/ha-google-home/const.py
+++ b/custom_components/ha-google-home/const.py
@@ -53,6 +53,7 @@ TIMEOUT = 10  # Request Timeout in seconds
 
 # TIMERS & ALARMS ATTRIBUTE NAMES
 ID = "id"
+LABEL = "label"
 RECURRENCE = "recurrence"
 FIRE_TIME = "fire_time"
 LOCAL_TIME = "local_time"

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -8,11 +8,11 @@ from .const import DATETIME_STR_FORMAT
 from .const import DURATION
 from .const import FIRE_TIME
 from .const import ID
+from .const import LABEL
 from .const import LOCAL_TIME
 from .const import LOCAL_TIME_ISO
 from .const import ORIGINAL_DURATION
 from .const import RECURRENCE
-from .const import LABEL
 
 
 def convert_from_ms_to_s(timestamp):

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -28,7 +28,8 @@ def format_timer_information(timer_dict):
     dt_utc = utc_from_timestamp(timer[FIRE_TIME])
     dt_local = as_local(dt_utc)
     timer[ID] = timer_dict[ID]
-    timer[LABEL] = timer_dict[LABEL]
+    if LABEL in timer_dict:
+        timer[LABEL] = timer_dict[LABEL]
     timer[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     timer[LOCAL_TIME_ISO] = dt_local.isoformat()
     timer[DURATION] = str(timedelta(seconds=duration))
@@ -43,7 +44,8 @@ def format_alarm_information(alarm_dict):
     dt_utc = utc_from_timestamp(alarm[FIRE_TIME])
     dt_local = as_local(dt_utc)
     alarm[ID] = alarm_dict[ID]
-    alarm[LABEL] = alarm_dict[LABEL]
+    if LABEL in alarm_dict:
+        alarm[LABEL] = alarm_dict[LABEL]
     alarm[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     alarm[LOCAL_TIME_ISO] = dt_local.isoformat()
     if alarm_dict.get(RECURRENCE):

--- a/custom_components/ha-google-home/utils.py
+++ b/custom_components/ha-google-home/utils.py
@@ -12,6 +12,7 @@ from .const import LOCAL_TIME
 from .const import LOCAL_TIME_ISO
 from .const import ORIGINAL_DURATION
 from .const import RECURRENCE
+from .const import LABEL
 
 
 def convert_from_ms_to_s(timestamp):
@@ -27,6 +28,7 @@ def format_timer_information(timer_dict):
     dt_utc = utc_from_timestamp(timer[FIRE_TIME])
     dt_local = as_local(dt_utc)
     timer[ID] = timer_dict[ID]
+    timer[LABEL] = timer_dict[LABEL]
     timer[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     timer[LOCAL_TIME_ISO] = dt_local.isoformat()
     timer[DURATION] = str(timedelta(seconds=duration))
@@ -41,6 +43,7 @@ def format_alarm_information(alarm_dict):
     dt_utc = utc_from_timestamp(alarm[FIRE_TIME])
     dt_local = as_local(dt_utc)
     alarm[ID] = alarm_dict[ID]
+    alarm[LABEL] = alarm_dict[LABEL]
     alarm[LOCAL_TIME] = dt_local.strftime(DATETIME_STR_FORMAT)
     alarm[LOCAL_TIME_ISO] = dt_local.isoformat()
     if alarm_dict.get(RECURRENCE):


### PR DESCRIPTION
Parses the `label` attribute to make it possible to show the name/label of the timer/alarm when it has one.