### PR TITLE
Add lovelace cards to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Make sure that you have your Home Assistant Container network set to 'host', as 
 
 ## Lovelace Cards
 
+<b>Open a PR to add your card here!</b>
+
 ### [Google Home timers card](https://github.com/DurgNomis-drol/google_home_timers_card)
 
 A simple way to display your timers in a card.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Make sure that you have your Home Assistant Container network set to 'host', as 
 
 ## Lovelace Cards
 
-<b>Open a PR to add your card here!</b>
+**Open a PR to add your card here!**
 
 ### [Google Home timers card](https://github.com/DurgNomis-drol/google_home_timers_card)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p>
   <p align="center">
     <a href="https://github.com/leikoilja/ha-google-home">
-      <img src="https://brands.home-assistant.io/ha-google-home/icon.png" alt="Logo" height="200">
+      <img src="https://brands.home-assistant.io/google_home/icon.png" alt="Logo" height="200">
     </a>
   </p>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ See <a href="#contribution">Contribution</a> section for more information.
 	</a></li>
       </ul>
     </li>
+    <li>
+      <a href="#lovelace-cards">Lovelace Cards</a>
+      <ul>
+         <li><a href="#google-home-timers-card">Google Home timers card</a></li>
+      </ul>
+    </li>
     <li><a href="#contribution">Contribution</a></li>
     <li><a href="#credits">Credits</a></li>
   </ol>
@@ -183,6 +189,12 @@ ln -s ha-google-home/custom_components/ha-google-home ~/.homeassistant/custom_co
 ### Running in Home Assistant Docker container
 
 Make sure that you have your Home Assistant Container network set to 'host', as perscribed in the official docker installation for Home Assistant.
+
+## Lovelace Cards
+
+### [Google Home timers card](https://github.com/DurgNomis-drol/google_home_timers_card) by [@DurgNomis-drol]
+
+A simple way to display your timers in a card.
 
 ## Contribution
 


### PR DESCRIPTION
Add lovelace cards to readme.

Reasoning is that it will be easier for the user find a card that is design for this integration.