### PR TITLE
Migrate from reorder-python-imports to isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,11 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: reorder-python-imports
-        name: Reorder python imports
-        entry: poetry run reorder-python-imports
+      - id: isort
+        name: isort
+        entry: poetry run isort
         language: system
         types: [python]
-        args: [--application-directories=custom_components]
         require_serial: true
       - id: flake8
         name: flake8

--- a/custom_components/google_home/__init__.py
+++ b/custom_components/google_home/__init__.py
@@ -5,27 +5,27 @@ For more details about this integration, please refer to
 https://github.com/leikoilja/ha-google-home
 """
 import asyncio
-import logging
 from datetime import timedelta
+import logging
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .api import GlocaltokensApiClient
-from .const import CONF_ANDROID_ID
-from .const import CONF_PASSWORD
-from .const import CONF_USERNAME
-from .const import DOMAIN
-from .const import PLATFORMS
-from .const import SENSOR
-from .const import STARTUP_MESSAGE
-from .const import UPDATE_INTERVAL
-
+from .const import (
+    CONF_ANDROID_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DOMAIN,
+    PLATFORMS,
+    SENSOR,
+    STARTUP_MESSAGE,
+    UPDATE_INTERVAL,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -1,28 +1,28 @@
 """Sample API Client."""
-import logging
 from asyncio import gather
+import logging
 
 import aiohttp
 from glocaltokens.client import GLocalAuthenticationTokens
 from glocaltokens.utils.token import is_aas_et
-from homeassistant.const import HTTP_NOT_FOUND
-from homeassistant.const import HTTP_OK
-from homeassistant.const import HTTP_UNAUTHORIZED
 from zeroconf import Zeroconf
 
-from .const import API_ENDPOINT_ALARMS
-from .const import API_RETURNED_UNKNOWN
-from .const import HEADER_CAST_LOCAL_AUTH
-from .const import HEADERS
-from .const import JSON_ALARM
-from .const import JSON_TIMER
-from .const import LABEL_ALARMS
-from .const import LABEL_TIMERS
-from .const import PORT
-from .const import SUPPORTED_HARDWARE_LIST
-from .const import TIMEOUT
-from .exceptions import InvalidMasterToken
+from homeassistant.const import HTTP_NOT_FOUND, HTTP_OK, HTTP_UNAUTHORIZED
 
+from .const import (
+    API_ENDPOINT_ALARMS,
+    API_RETURNED_UNKNOWN,
+    HEADER_CAST_LOCAL_AUTH,
+    HEADERS,
+    JSON_ALARM,
+    JSON_TIMER,
+    LABEL_ALARMS,
+    LABEL_TIMERS,
+    PORT,
+    SUPPORTED_HARDWARE_LIST,
+    TIMEOUT,
+)
+from .exceptions import InvalidMasterToken
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -1,23 +1,25 @@
 """Adds config flow for Google Home"""
 import logging
 
+from requests.exceptions import RequestException
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from requests.exceptions import RequestException
 
 from .api import GlocaltokensApiClient
-from .const import CONF_ANDROID_ID
-from .const import CONF_MASTER_TOKEN
-from .const import CONF_PASSWORD
-from .const import CONF_USERNAME
-from .const import DOMAIN  # pylint: disable=unused-import
-from .const import PLATFORMS
-from .exceptions import InvalidMasterToken
+from .const import (
+    CONF_ANDROID_ID,
+    CONF_MASTER_TOKEN,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    PLATFORMS,
+)
 
 # Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
-
+from .const import DOMAIN  # pylint: disable=unused-import
+from .exceptions import InvalidMasterToken
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -1,17 +1,19 @@
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEFAULT_NAME
-from .const import DOMAIN
-from .const import ICON_ALARMS
-from .const import ICON_TIMERS
-from .const import ICON_TOKEN
-from .const import LABEL_ALARMS
-from .const import LABEL_NEXT_ALARM
-from .const import LABEL_NEXT_TIMER
-from .const import LABEL_TIMERS
-from .const import LABEL_TOKEN
-from .const import MANUFACTURER
-from .const import VERSION
+from .const import (
+    DEFAULT_NAME,
+    DOMAIN,
+    ICON_ALARMS,
+    ICON_TIMERS,
+    ICON_TOKEN,
+    LABEL_ALARMS,
+    LABEL_NEXT_ALARM,
+    LABEL_NEXT_TIMER,
+    LABEL_TIMERS,
+    LABEL_TOKEN,
+    MANUFACTURER,
+    VERSION,
+)
 
 
 class GoogleHomeTokenEntity(CoordinatorEntity):

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -1,23 +1,27 @@
 """Sensor platforms for Google Home"""
 import logging
 
-from homeassistant.const import STATE_OFF
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 
-from .const import DOMAIN
-from .const import LABEL_ALARMS
-from .const import LABEL_TIMERS
-from .const import LOCAL_TIME_ISO
-from .const import SUPPORTED_HARDWARE_LIST
-from .entity import GoogleHomeAlarmEntity
-from .entity import GoogleHomeNextAlarmEntity
-from .entity import GoogleHomeNextTimerEntity
-from .entity import GoogleHomeTimersEntity
-from .entity import GoogleHomeTokenEntity
-from .utils import format_alarm_information
-from .utils import format_timer_information
-from .utils import sort_list_by_firetime
-
+from .const import (
+    DOMAIN,
+    LABEL_ALARMS,
+    LABEL_TIMERS,
+    LOCAL_TIME_ISO,
+    SUPPORTED_HARDWARE_LIST,
+)
+from .entity import (
+    GoogleHomeAlarmEntity,
+    GoogleHomeNextAlarmEntity,
+    GoogleHomeNextTimerEntity,
+    GoogleHomeTimersEntity,
+    GoogleHomeTokenEntity,
+)
+from .utils import (
+    format_alarm_information,
+    format_timer_information,
+    sort_list_by_firetime,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/google_home/utils.py
+++ b/custom_components/google_home/utils.py
@@ -1,18 +1,19 @@
 """utils.py for google home integration"""
 from datetime import timedelta
 
-from homeassistant.util.dt import as_local
-from homeassistant.util.dt import utc_from_timestamp
+from homeassistant.util.dt import as_local, utc_from_timestamp
 
-from .const import DATETIME_STR_FORMAT
-from .const import DURATION
-from .const import FIRE_TIME
-from .const import ID
-from .const import LABEL
-from .const import LOCAL_TIME
-from .const import LOCAL_TIME_ISO
-from .const import ORIGINAL_DURATION
-from .const import RECURRENCE
+from .const import (
+    DATETIME_STR_FORMAT,
+    DURATION,
+    FIRE_TIME,
+    ID,
+    LABEL,
+    LOCAL_TIME,
+    LOCAL_TIME_ISO,
+    ORIGINAL_DURATION,
+    RECURRENCE,
+)
 
 
 def convert_from_ms_to_s(timestamp):

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,17 +26,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "aspy.refactor-imports"
-version = "2.2.0"
-description = "Utilities for refactoring imports in python-like syntax."
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-cached-property = "*"
-
-[[package]]
 name = "astral"
 version = "1.10.1"
 description = "Calculations for the position of the sun and moon."
@@ -128,14 +117,6 @@ typing-extensions = ">=3.7.4"
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
-
-[[package]]
-name = "cached-property"
-version = "1.5.2"
-description = "A decorator for caching properties in classes."
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "certifi"
@@ -608,17 +589,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "reorder-python-imports"
-version = "2.4.0"
-description = "Tool for reordering python imports"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-"aspy.refactor-imports" = ">=2.1.0"
-
-[[package]]
 name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
@@ -802,7 +772,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fff195edca6cf6e8052a01136a6dd3f80962e3668192f1addbb5e7a0734356db"
+content-hash = "105f2802381f6105c180b650097d3bfd4a7cad6aa3c34cb9d013fff6bd8b7568"
 
 [metadata.files]
 aiohttp = [
@@ -848,10 +818,6 @@ appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
-"aspy.refactor-imports" = [
-    {file = "aspy.refactor_imports-2.2.0-py2.py3-none-any.whl", hash = "sha256:7a18039d2e8be6b02b4791ce98891deb46b459b575c52ed35ab818c4eaa0c098"},
-    {file = "aspy.refactor_imports-2.2.0.tar.gz", hash = "sha256:78ca24122963fd258ebfc4a8dc708d23a18040ee39dca8767675821e84e9ea0a"},
-]
 astral = [
     {file = "astral-1.10.1-py2.py3-none-any.whl", hash = "sha256:5cca85e6e810cb6a38d248622c49e82f14e768bae791468aefbfe3c4c90cc00e"},
     {file = "astral-1.10.1.tar.gz", hash = "sha256:d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1"},
@@ -895,10 +861,6 @@ bcrypt = [
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
-]
-cached-property = [
-    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
-    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -1341,18 +1303,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -1399,10 +1369,6 @@ regex = [
     {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
     {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
-]
-reorder-python-imports = [
-    {file = "reorder_python_imports-2.4.0-py2.py3-none-any.whl", hash = "sha256:995a2a93684af31837f30cf2bcddce2e7eb17f0d2d69c9905da103baf8cec42b"},
-    {file = "reorder_python_imports-2.4.0.tar.gz", hash = "sha256:9a9e7774d66e9b410b619f934e8206a63dce5be26bd894f5006eb764bba6a26d"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ homeassistant = "^2021.3.2"
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
 flake8 = "^3.8.4"
-reorder-python-imports = "^2.4.0"
 pre-commit = "^2.10.1"
 pylint = "^2.7.2"
+isort = "^5.7.0"
 
 [tool.pylint.messages_control]
 disable = [
@@ -34,6 +34,14 @@ disable = [
 
 [tool.pylint.format]
 max-line-length = 88
+
+[tool.isort]
+profile = "black"
+force_sort_within_sections = true
+combine_as_imports = true
+known_first_party = [
+    "homeassistant",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
I noticed that `reorder-python-imports` doesn't work well with `black` and can start fighting with it.

Home Assistant uses `isort` and it's much more popular across python projects, let's switch to it and adopt Home Assistant config. It supports `black` much better.

# Example
### reorder-python-imports
Initial code:
```python3
from .api import GlocaltokensApiClient
from .const import CONF_ANDROID_ID
from .const import CONF_MASTER_TOKEN
from .const import CONF_PASSWORD
from .const import CONF_USERNAME
# Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
from .const import DOMAIN  # pylint: disable=unused-import
from .const import PLATFORMS
from .exceptions import InvalidMasterToken
```

First pass. `Black` reformats and then `reorder-python-imports` reformats again:
```python3
from .api import GlocaltokensApiClient
from .const import CONF_ANDROID_ID
from .const import CONF_MASTER_TOKEN
from .const import CONF_PASSWORD
from .const import CONF_USERNAME
from .const import DOMAIN  # pylint: disable=unused-import
from .const import PLATFORMS
from .exceptions import InvalidMasterToken
# Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
```

Second pass. `Black` reformats, `reorder-python-imports` doesn't change:
```python3
from .api import GlocaltokensApiClient
from .const import CONF_ANDROID_ID
from .const import CONF_MASTER_TOKEN
from .const import CONF_PASSWORD
from .const import CONF_USERNAME
from .const import DOMAIN  # pylint: disable=unused-import
from .const import PLATFORMS
from .exceptions import InvalidMasterToken

# Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
```

And after that it stabilises.

### isort
Initial code:
```python3
from .api import GlocaltokensApiClient
from .const import (
    CONF_ANDROID_ID,
    CONF_MASTER_TOKEN,
    CONF_PASSWORD,
    CONF_USERNAME,
    PLATFORMS,
)
# Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
from .const import DOMAIN  # pylint: disable=unused-import
from .exceptions import InvalidMasterToken
```

Stabilises after the first pass:
```python3
from .api import GlocaltokensApiClient
from .const import (
    CONF_ANDROID_ID,
    CONF_MASTER_TOKEN,
    CONF_PASSWORD,
    CONF_USERNAME,
    PLATFORMS,
)

# Pylint issue should be fixed by https://github.com/PyCQA/pylint/pull/4207
from .const import DOMAIN  # pylint: disable=unused-import
from .exceptions import InvalidMasterToken
```