### PR TITLE
Use simple format for tables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ tokens and use those tokens making API calls to Google Home devices.
 
 This component will set up the following platforms:
 
-| Platform | Sample sensor                   | Description                                               |
-| -------- | ------------------------------- | --------------------------------------------------------- |
-| `sensor` | `sensor.living_room_timers`     | Sensor with a list of timers from the device              |
-| `sensor` | `sensor.living_room_next_timer` | Sensor with next timer from the device                    |
-| `sensor` | `sensor.living_room_alarms`     | Sensor with a list of alarms from the device              |
-| `sensor` | `sensor.living_room_next_alarm` | Sensor with next alarm from the device                    |
-| `sensor` | `sensor.living_room_token`      | Sensor with the local authentication token for the device |
+Platform | Sample sensor                   | Description
+-------- | -------------                   | -----------
+`sensor` | `sensor.living_room_timers`     | Sensor with a list of timers from the device
+`sensor` | `sensor.living_room_next_timer` | Sensor with next timer from the device
+`sensor` | `sensor.living_room_alarms`     | Sensor with a list of alarms from the device
+`sensor` | `sensor.living_room_next_alarm` | Sensor with next alarm from the device
+`sensor` | `sensor.living_room_token`      | Sensor with the local authentication token for the device
 
 ### Timers
 
@@ -66,14 +66,14 @@ You can have multiple timers on your Google Home device. The Home Assistant
 timers sensor will represent all of them in the state attributes as a list "timers".
 Each of timers has the following keys:
 
-| Key              | Value type                   | Description                                                               |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `id`             | Google Home corresponding ID | Used to delete/modify timer                                               |
-| `label`          | Name                         | Name of the timer, this can be set when making the timer                  |
-| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off         |
-| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
-| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
-| `duration`       | Seconds                      | Timer duration in seconds                                                 |
+Key              | Value type                   | Description
+---              | ----------                   | -----------
+`id`             | Google Home corresponding ID | Used to delete/modify timer
+`label`          | Name                         | Name of the timer, this can be set when making the timer
+`fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off
+`local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone
+`local_time_iso` | Time in ISO 8601 standard    | Useful for automations
+`duration`       | Seconds                      | Timer duration in seconds
 
 ### Next timer
 
@@ -88,14 +88,14 @@ alarms sensor will represent all of them in the state attributes as a list
 "alarms".
 Each of alarms has the following keys:
 
-| Key              | Value type                   | Description                                                                                                                                                                                             |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | Google Home corresponding ID | Used to delete/modify alarm                                                                                                                                                                             |
-| `label`          | Name                         | Name of the alarm, this can be set when making the alarm                                                                                                                                                |
-| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the alarm goes off                                                                                                                                       |
-| `local_time`     | Time                         | Time when the alarm goes off, in respect to the Home Assistant's timezone                                                                                                                               |
-| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                                                                                                                                                  |
-| `recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
+Key              | Value type                   | Description
+---              | ----------                   | -----------
+`id`             | Google Home corresponding ID | Used to delete/modify alarm
+`label`          | Name                         | Name of the alarm, this can be set when making the alarm
+`fire_time`      | Seconds                      | Raw value coming from Google Home device until the alarm goes off
+`local_time`     | Time                         | Time when the alarm goes off, in respect to the Home Assistant's timezone
+`local_time_iso` | Time in ISO 8601 standard    | Useful for automations
+`recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on
 
 ### Next alarm
 


### PR DESCRIPTION
Without outer border they're easier to maintain and look nicer (especially the last one) in editors with word wrapping like github.

Github guides also suggest such format: https://guides.github.com/features/mastering-markdown/

No visual changes here.