### PR TITLE
Use lazy % formatting in logging functions

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -98,9 +98,9 @@ class GlocaltokensApiClient:
         """Fetches timers and alarms from google device"""
         url = self.create_url(device.ip, PORT, API_ENDPOINT_ALARMS)
         _LOGGER.debug(
-            "Fetching data from Google Home device {device} - {url}".format(
-                device=device.device_name, url=url
-            )
+            "Fetching data from Google Home device %s - %s",
+            device.device_name,
+            url,
         )
         HEADERS[HEADER_CAST_LOCAL_AUTH] = device.local_auth_token
 
@@ -113,35 +113,29 @@ class GlocaltokensApiClient:
                 # and rerun the task.
                 _LOGGER.debug(
                     (
-                        "Failed to fetch data from {device} due to invalid token. "
+                        "Failed to fetch data from %s due to invalid token. "
                         "Will refresh the token and try again."
-                    ).format(
-                        device=device.device_name,
-                    )
+                    ),
+                    device.device_name,
                 )
                 self.google_devices = []
             elif response.status == HTTP_NOT_FOUND:
                 _LOGGER.debug(
                     (
-                        "Failed to fetch data from {device}, API returned {code}. "
-                        "The device(hardware='{hardware}') is not Google Home "
+                        "Failed to fetch data from %s, API returned %d. "
+                        "The device(hardware='%s') is not Google Home "
                         "compatable and has no alarms/timers."
-                    ).format(
-                        device=device.device_name,
-                        code=response.status,
-                        hardware=device.hardware,
-                    )
+                    ),
+                    device.device_name,
+                    response.status,
+                    device.hardware,
                 )
             else:
                 _LOGGER.error(
-                    (
-                        "Failed to fetch {device} data, "
-                        "API returned {code}: {response}"
-                    ).format(
-                        device=device.device_name,
-                        code=response.status,
-                        response=response,
-                    )
+                    "Failed to fetch %s data, API returned %d: %s",
+                    device.device_name,
+                    response.status,
+                    response,
                 )
 
         if resp:
@@ -150,10 +144,9 @@ class GlocaltokensApiClient:
                 setattr(device, LABEL_ALARMS, resp.get(JSON_ALARM, []))
             else:
                 _LOGGER.error(
-                    "For device {device} - {error}".format(
-                        device=device.device_name,
-                        error=API_RETURNED_UNKNOWN,
-                    )
+                    "For device %s - %s",
+                    device.device_name,
+                    API_RETURNED_UNKNOWN,
                 )
         return device
 
@@ -169,10 +162,11 @@ class GlocaltokensApiClient:
                 _LOGGER.debug(
                     (
                         "Failed to fetch timers/alarms information "
-                        "from device {device}. We could not determine it's IP address, "
+                        "from device %s. We could not determine it's IP address, "
                         "the device is either offline or is not compatable "
                         "Google Home device. Will try again later."
-                    ).format(device=device.device_name)
+                    ),
+                    device.device_name,
                 )
 
         coordinator_data = await gather(

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -69,12 +69,11 @@ async def async_setup_entry(hass, entry, async_add_devices):
             else:
                 _LOGGER.warning(
                     (
-                        "The {device} device(hardware='{hardware}') is not Google Home "
+                        "The %s device(hardware='%s') is not Google Home "
                         "compatible and has no alarms/timers"
-                    ).format(
-                        device=device.device_name,
-                        hardware=device.hardware,
-                    )
+                    ),
+                    device.device_name,
+                    device.hardware,
                 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ isort = "^5.7.0"
 
 [tool.pylint.messages_control]
 disable = [
-    "logging-format-interpolation",
     "missing-class-docstring",
     "missing-function-docstring",
     "missing-module-docstring",


### PR DESCRIPTION
There is some controversy in python community about this check:
- https://github.com/PyCQA/pylint/issues/1788
- https://github.com/PyCQA/pylint/issues/2395

As I understand it, the main idea here is do not evaluate logging strings if they're not going to be printed.
I checked that Home Assistant follows this, so let's do the same.

@leikoilja sorry, you'll need to rebase one more time