### PR TITLE
Fix no-member warning

### DIFF
--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -17,9 +17,9 @@ from .const import (
 
 
 class GoogleHomeDeviceEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator, device_name):
         super().__init__(coordinator)
-        self.config_entry = config_entry
+        self.device_name = device_name
 
     @property
     def device_info(self):
@@ -46,20 +46,15 @@ class GoogleHomeDeviceEntity(CoordinatorEntity):
         return ICON_TOKEN
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
     def device_class(self):
         """Return de device class of the sensor."""
         return "google_home__custom_device_class"
 
 
 class GoogleHomeAlarmEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator, device_name):
         super().__init__(coordinator)
-        self.config_entry = config_entry
+        self.device_name = device_name
 
     @property
     def device_info(self):
@@ -85,16 +80,11 @@ class GoogleHomeAlarmEntity(CoordinatorEntity):
         """Icon to use in the frontend, if any."""
         return ICON_ALARMS
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
 
 class GoogleHomeNextAlarmEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator, device_name):
         super().__init__(coordinator)
-        self.config_entry = config_entry
+        self.device_name = device_name
 
     @property
     def device_info(self):
@@ -122,9 +112,9 @@ class GoogleHomeNextAlarmEntity(CoordinatorEntity):
 
 
 class GoogleHomeTimersEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator, device_name):
         super().__init__(coordinator)
-        self.config_entry = config_entry
+        self.device_name = device_name
 
     @property
     def name(self):
@@ -150,16 +140,11 @@ class GoogleHomeTimersEntity(CoordinatorEntity):
         """Icon to use in the frontend, if any."""
         return ICON_TIMERS
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
 
 class GoogleHomeNextTimerEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator, device_name):
         super().__init__(coordinator)
-        self.config_entry = config_entry
+        self.device_name = device_name
 
     @property
     def device_info(self):

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -23,7 +23,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
         sensors.append(
             GoogleHomeDeviceSensor(
                 coordinator,
-                entry,
                 device.name,
                 device.auth_token,
             )
@@ -32,22 +31,18 @@ async def async_setup_entry(hass, entry, async_add_devices):
             sensors += [
                 GoogleHomeAlarmSensor(
                     coordinator,
-                    entry,
                     device.name,
                 ),
                 GoogleHomeNextAlarmSensor(
                     coordinator,
-                    entry,
                     device.name,
                 ),
                 GoogleHomeTimerSensor(
                     coordinator,
-                    entry,
                     device.name,
                 ),
                 GoogleHomeNextTimerSensor(
                     coordinator,
-                    entry,
                     device.name,
                 ),
             ]
@@ -76,10 +71,9 @@ class GoogleHomeSensorMixin:
 class GoogleHomeDeviceSensor(GoogleHomeSensorMixin, GoogleHomeDeviceEntity):
     """GoogleHome Device Sensor class."""
 
-    def __init__(self, coordinator, entry, device_name, auth_token):
+    def __init__(self, coordinator, device_name, auth_token):
         """Initialize the sensor."""
-        super().__init__(coordinator, entry)
-        self.device_name = device_name
+        super().__init__(coordinator, device_name)
         self.auth_token = auth_token
 
     @property
@@ -119,11 +113,6 @@ class GoogleHomeDeviceSensor(GoogleHomeSensorMixin, GoogleHomeDeviceEntity):
 class GoogleHomeAlarmSensor(GoogleHomeSensorMixin, GoogleHomeAlarmEntity):
     """Representation of a Sensor."""
 
-    def __init__(self, coordinator, entry, device_name):
-        """Initialize the sensor."""
-        super().__init__(coordinator, entry)
-        self.device_name = device_name
-
     @property
     def state(self):
         alarms = self._get_alarms_data()
@@ -146,11 +135,6 @@ class GoogleHomeAlarmSensor(GoogleHomeSensorMixin, GoogleHomeAlarmEntity):
 
 class GoogleHomeNextAlarmSensor(GoogleHomeSensorMixin, GoogleHomeNextAlarmEntity):
     """Representation of a Sensor."""
-
-    def __init__(self, coordinator, entry, device_name):
-        """Initialize the sensor."""
-        super().__init__(coordinator, entry)
-        self.device_name = device_name
 
     @property
     def state(self):
@@ -179,11 +163,6 @@ class GoogleHomeNextAlarmSensor(GoogleHomeSensorMixin, GoogleHomeNextAlarmEntity
 class GoogleHomeTimerSensor(GoogleHomeSensorMixin, GoogleHomeTimersEntity):
     """Representation of a Sensor."""
 
-    def __init__(self, coordinator, entry, device_name):
-        """Initialize the sensor."""
-        super().__init__(coordinator, entry)
-        self.device_name = device_name
-
     @property
     def state(self):
         timers = self._get_timers_data()
@@ -205,11 +184,6 @@ class GoogleHomeTimerSensor(GoogleHomeSensorMixin, GoogleHomeTimersEntity):
 
 class GoogleHomeNextTimerSensor(GoogleHomeSensorMixin, GoogleHomeNextTimerEntity):
     """Representation of a Sensor."""
-
-    def __init__(self, coordinator, entry, device_name):
-        """Initialize the sensor."""
-        super().__init__(coordinator, entry)
-        self.device_name = device_name
 
     @property
     def state(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ disable = [
     "missing-class-docstring",
     "missing-function-docstring",
     "missing-module-docstring",
-    "no-member",
     "too-few-public-methods",
     "too-many-arguments",
     "too-many-instance-attributes",


### PR DESCRIPTION
This file is pretty messy.
- `state` is defined on `sensor` level
- It was using `_name` from child classes
- `entry` is not used
- rename `_name` to `device_name`. Varible name starting with `_` usually means that it's not used, that's not true here
I tested that it still works after these changes.