### PR TITLE
Fix unused-argument warning

### DIFF
--- a/custom_components/google_home/__init__.py
+++ b/custom_components/google_home/__init__.py
@@ -30,7 +30,7 @@ from .const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
+async def async_setup(_hass: HomeAssistant, _config: Config):
     """Set up this integration using YAML is not supported."""
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ pylint = "^2.7.2"
 isort = "^5.7.0"
 
 [tool.pylint.messages_control]
+# Reasons disabled:
+# too-many-* - not enforced for the sake of readability
+# too-few-* - same as too-many-*
 disable = [
     "missing-class-docstring",
     "missing-function-docstring",
@@ -27,7 +30,6 @@ disable = [
     "too-few-public-methods",
     "too-many-arguments",
     "too-many-instance-attributes",
-    "unused-argument",
 ]
 
 [tool.pylint.format]


### PR DESCRIPTION
This is pretty useful check. The last one which needs to be fixed except docstrings.

Mark `hass` and `config` as unsed by `_` prefix.