### PR TITLE
Enable mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
         language: system
         types: [python]
         require_serial: true
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types: [python]
       - id: flake8
         name: flake8
         entry: poetry run flake8

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -1,6 +1,7 @@
 """Sample API Client."""
 from asyncio import gather
 import logging
+from typing import List
 
 import aiohttp
 from glocaltokens.client import GLocalAuthenticationTokens
@@ -46,7 +47,7 @@ class GlocaltokensApiClient:
         self._client = GLocalAuthenticationTokens(
             username=username, password=password, android_id=android_id
         )
-        self.google_devices = []
+        self.google_devices: List[GoogleHomeDevice] = []
         self.zeroconf_instance = zeroconf_instance
 
     async def async_get_master_token(self):

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -24,7 +24,8 @@ from .exceptions import InvalidMasterToken
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+# Need typed homeassistant stubs to fix this for mypy
+class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Config flow for GoogleHome."""
 
     VERSION = 1

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -1,7 +1,9 @@
 """Models for Google Home"""
 
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from homeassistant.util.dt import as_local, utc_from_timestamp
 
@@ -15,7 +17,7 @@ from .const import (
 )
 
 
-def convert_from_ms_to_s(timestamp):
+def convert_from_ms_to_s(timestamp: int) -> int:
     """Converts from milliseconds to seconds"""
     return round(timestamp / 1000)
 
@@ -29,7 +31,7 @@ class GoogleHomeDevice:
         auth_token: str,
         ip_address: Optional[str] = None,
         hardware: Optional[str] = None,
-    ) -> None:
+    ):
         self.name = name
         self.auth_token = auth_token
         self.ip_address = ip_address
@@ -38,7 +40,7 @@ class GoogleHomeDevice:
         self._timers: List[GoogleHomeTimer] = []
         self._alarms: List[GoogleHomeAlarm] = []
 
-    def set_alarms(self, alarms):
+    def set_alarms(self, alarms: List[Dict[str, Any]]) -> None:
         """Stores alarms as GoogleHomeAlarm objects"""
         self._alarms = [
             GoogleHomeAlarm(
@@ -50,7 +52,7 @@ class GoogleHomeDevice:
             for alarm in alarms
         ]
 
-    def set_timers(self, timers):
+    def set_timers(self, timers: List[Dict[str, Any]]) -> None:
         """Stores timers as GoogleHomeTimer objects"""
         self._timers = [
             GoogleHomeTimer(
@@ -62,20 +64,20 @@ class GoogleHomeDevice:
             for timer in timers
         ]
 
-    def get_sorted_alarms(self):
+    def get_sorted_alarms(self) -> List[GoogleHomeAlarm]:
         """Returns alarms in a sorted order"""
         return sorted(self._alarms, key=lambda k: k.fire_time)
 
-    def get_next_alarm(self):
+    def get_next_alarm(self) -> Optional[GoogleHomeAlarm]:
         """Returns next alarm"""
         alarms = self.get_sorted_alarms()
         return alarms[0] if alarms else None
 
-    def get_sorted_timers(self):
+    def get_sorted_timers(self) -> List[GoogleHomeTimer]:
         """Returns timers in a sorted order"""
         return sorted(self._timers, key=lambda k: k.fire_time)
 
-    def get_next_timer(self):
+    def get_next_timer(self) -> Optional[GoogleHomeTimer]:
         """Returns next alarm"""
         timers = self.get_sorted_timers()
         return timers[0] if timers else None
@@ -86,10 +88,10 @@ class GoogleHomeTimer:
 
     def __init__(
         self,
-        timer_id,
-        fire_time,
-        duration,
-        label,
+        timer_id: str,
+        fire_time: int,
+        duration: int,
+        label: Optional[str],
     ) -> None:
         self.timer_id = timer_id
         self.duration = str(timedelta(seconds=convert_from_ms_to_s(duration)))
@@ -105,7 +107,13 @@ class GoogleHomeTimer:
 class GoogleHomeAlarm:
     """Local representation of Google Home alarm"""
 
-    def __init__(self, alarm_id, fire_time, label, recurrence) -> None:
+    def __init__(
+        self,
+        alarm_id: str,
+        fire_time: int,
+        label: Optional[str],
+        recurrence: Optional[str],
+    ) -> None:
         self.alarm_id = alarm_id
         self.recurrence = recurrence
         self.fire_time = convert_from_ms_to_s(fire_time)

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -1,7 +1,7 @@
 """Models for Google Home"""
 
 from datetime import timedelta
-from typing import Optional
+from typing import List, Optional
 
 from homeassistant.util.dt import as_local, utc_from_timestamp
 
@@ -35,8 +35,8 @@ class GoogleHomeDevice:
         self.ip_address = ip_address
         self.hardware = hardware
         self.available = True
-        self._timers = []
-        self._alarms = []
+        self._timers: List[GoogleHomeTimer] = []
+        self._alarms: List[GoogleHomeAlarm] = []
 
     def set_alarms(self, alarms):
         """Stores alarms as GoogleHomeAlarm objects"""

--- a/poetry.lock
+++ b/poetry.lock
@@ -437,6 +437,22 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "mypy"
+version = "0.812"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -772,7 +788,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "105f2802381f6105c180b650097d3bfd4a7cad6aa3c34cb9d013fff6bd8b7568"
+content-hash = "8be423832d555233c41072b0eae215655b9b461ed71caf5f2ef7efa3a6a0c89c"
 
 [metadata.files]
 aiohttp = [
@@ -1199,6 +1215,30 @@ multidict = [
     {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
     {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
+mypy = [
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1303,26 +1343,18 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^3.8.4"
 pre-commit = "^2.10.1"
 pylint = "^2.7.2"
 isort = "^5.7.0"
+mypy = "^0.812"
 
 [tool.pylint.messages_control]
 # Reasons disabled:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,15 @@ ignore =
     E203,
     D202,
     W504
+
+[mypy]
+python_version = 3.8
+
+[mypy-glocaltokens.*]
+ignore_missing_imports = True
+
+[mypy-homeassistant.*]
+ignore_missing_imports = True
+
+[mypy-voluptuous.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Add it to `pre-commit` config.

Unfortunately, `homeassistant`, `voluptuous` and `glocaltokens` don't distribute typing information.

I'll try to enable it for `homeassistant`.
@leikoilja can you enable this for `glocaltokens`? Should be one line in `setup.py`.
https://www.python.org/dev/peps/pep-0561/