### PR TITLE
Catch exceptions when getting alarms and timers to better allow for debugging

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -151,13 +151,13 @@ class GlocaltokensApiClient:
                         response.status,
                         response,
                     )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as ex:  # pylint: disable=broad-except
             # Make sure that we log the exception if one occurred.
             # The only reason we do this broad is so we easily can
             # debug the application.
             _LOGGER.error(
                 "Request error: %s",
-                exc,
+                ex,
             )
         finally:
             if resp:

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -151,7 +151,7 @@ class GlocaltokensApiClient:
                         response.status,
                         response,
                     )
-        except Exception as ex:  # pylint: disable=broad-except
+        except aiohttp.ClientError as ex:
             # Make sure that we log the exception if one occurred.
             # The only reason we do this broad is so we easily can
             # debug the application.

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -113,51 +113,62 @@ class GlocaltokensApiClient:
         HEADERS[HEADER_CAST_LOCAL_AUTH] = device.auth_token
 
         resp = None
-        async with self._session.get(url, headers=HEADERS, timeout=TIMEOUT) as response:
-            if response.status == HTTP_OK:
-                resp = await response.json()
-            elif response.status == HTTP_UNAUTHORIZED:
-                # If token is invalid - force reload homegraph providing new token
-                # and rerun the task.
-                _LOGGER.debug(
-                    (
-                        "Failed to fetch data from %s due to invalid token. "
-                        "Will refresh the token and try again."
-                    ),
-                    device.name,
-                )
-                # We need to retry the update task instead of just cleaning the list
-                self.google_devices = []
-            elif response.status == HTTP_NOT_FOUND:
-                device.available = False
-                _LOGGER.debug(
-                    (
-                        "Failed to fetch data from %s, API returned %d. "
-                        "The device(hardware='%s') is not Google Home "
-                        "compatable and has no alarms/timers."
-                    ),
-                    device.name,
-                    response.status,
-                    device.hardware,
-                )
-            else:
-                _LOGGER.error(
-                    "Failed to fetch %s data, API returned %d: %s",
-                    device.name,
-                    response.status,
-                    response,
-                )
 
-        if resp:
-            if JSON_TIMER in resp or JSON_ALARM in resp:
-                device.set_timers(resp.get(JSON_TIMER))
-                device.set_alarms(resp.get(JSON_ALARM))
-            else:
-                _LOGGER.error(
-                    "For device %s - %s",
-                    device.name,
-                    API_RETURNED_UNKNOWN,
-                )
+        try:
+            async with self._session.get(
+                url, headers=HEADERS, timeout=TIMEOUT
+            ) as response:
+                if response.status == HTTP_OK:
+                    resp = await response.json()
+                elif response.status == HTTP_UNAUTHORIZED:
+                    # If token is invalid - force reload homegraph providing new token
+                    # and rerun the task.
+                    _LOGGER.debug(
+                        (
+                            "Failed to fetch data from %s due to invalid token. "
+                            "Will refresh the token and try again."
+                        ),
+                        device.name,
+                    )
+                    # We need to retry the update task instead of just cleaning the list
+                    self.google_devices = []
+                elif response.status == HTTP_NOT_FOUND:
+                    device.available = False
+                    _LOGGER.debug(
+                        (
+                            "Failed to fetch data from %s, API returned %d. "
+                            "The device(hardware='%s') is not Google Home "
+                            "compatable and has no alarms/timers."
+                        ),
+                        device.name,
+                        response.status,
+                        device.hardware,
+                    )
+                else:
+                    _LOGGER.error(
+                        "Failed to fetch %s data, API returned %d: %s",
+                        device.name,
+                        response.status,
+                        response,
+                    )
+        except Exception as exc:  # pylint: disable=broad-except
+            # Make sure that we log the exception if one occurred.
+            # The only reason we do this broad is so we easily can debug the application.
+            _LOGGER.error(
+                "Request error: %s",
+                exc,
+            )
+        finally:
+            if resp:
+                if JSON_TIMER in resp or JSON_ALARM in resp:
+                    device.set_timers(resp.get(JSON_TIMER))
+                    device.set_alarms(resp.get(JSON_ALARM))
+                else:
+                    _LOGGER.error(
+                        "For device %s - %s",
+                        device.name,
+                        API_RETURNED_UNKNOWN,
+                    )
         return device
 
     async def update_google_devices_information(self):

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -153,7 +153,8 @@ class GlocaltokensApiClient:
                     )
         except Exception as exc:  # pylint: disable=broad-except
             # Make sure that we log the exception if one occurred.
-            # The only reason we do this broad is so we easily can debug the application.
+            # The only reason we do this broad is so we easily can
+            # debug the application.
             _LOGGER.error(
                 "Request error: %s",
                 exc,


### PR DESCRIPTION
This should handle these to problems and allow for us in the future to better debug if the underlaying package is throwing an exceptions when retrieving data from each device. 

We need some one with problem to test it first so we can confirm that it solves the problem. I have tested it on my machine and it works.

Should close #100 and #102 


More info:

The error both of them gets, is an exception thrown by, in this case, `aiohttp` because those devices does not conform. We should just skip those devices and log them.