### PR TITLE
Reduce code duplication in entities

### DIFF
--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -5,7 +5,6 @@ from homeassistant.util.dt import DATE_STR_FORMAT
 NAME = "Google Home community driven integration"
 DOMAIN = "google_home"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "v0.0.0"
 MANUFACTURER = "google_home"
 
 ATTRIBUTION = "json"

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -1,27 +1,13 @@
 """Defines base entities for Google Home"""
 
-from typing import Set, Tuple, TypedDict
+from typing import Any, Dict, List, Set, Tuple, TypedDict
 
-from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
 
-from .const import (
-    DEFAULT_NAME,
-    DOMAIN,
-    ICON_ALARMS,
-    ICON_TIMERS,
-    ICON_TOKEN,
-    LABEL_ALARMS,
-    LABEL_DEVICE,
-    LABEL_NEXT_ALARM,
-    LABEL_NEXT_TIMER,
-    LABEL_TIMERS,
-    MANUFACTURER,
-    VERSION,
-)
+from .const import DEFAULT_NAME, DOMAIN, MANUFACTURER
 
 
 class DeviceInfo(TypedDict):
@@ -29,12 +15,11 @@ class DeviceInfo(TypedDict):
 
     identifiers: Set[Tuple[str, str]]
     name: str
-    model: str
     manufacturer: str
 
 
-class GoogleHomeDeviceEntity(CoordinatorEntity):
-    """Entity base for device sensor"""
+class GoogleHomeBaseEntity(CoordinatorEntity):
+    """Base entity base for Google Home sensors"""
 
     def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
         super().__init__(coordinator)
@@ -45,164 +30,22 @@ class GoogleHomeDeviceEntity(CoordinatorEntity):
         return {
             "identifiers": {(DOMAIN, self.device_name)},
             "name": f"{DEFAULT_NAME} {self.device_name}",
-            "model": VERSION,
             "manufacturer": MANUFACTURER,
         }
 
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_DEVICE}"
+    def get_device(self):
+        """Return the device matched by device name
+        from the list of google devices in coordinator_data"""
+        return next(
+            (
+                device
+                for device in self.coordinator.data
+                if device.name == self.device_name
+            ),
+            None,
+        )
 
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_DEVICE}"
-
-    @property
-    def icon(self) -> str:
-        """Return the icon of the sensor."""
-        return ICON_TOKEN
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class of the sensor."""
-        return "google_home__custom_device_class"
-
-
-class GoogleHomeAlarmEntity(CoordinatorEntity):
-    """Entity base for Alarm sensor"""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
-        super().__init__(coordinator)
-        self.device_name = device_name
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return {
-            "identifiers": {(DOMAIN, self.device_name)},
-            "name": f"{DEFAULT_NAME} {self.device_name}",
-            "model": VERSION,
-            "manufacturer": MANUFACTURER,
-        }
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_ALARMS}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_ALARMS}"
-
-    @property
-    def icon(self) -> str:
-        """Icon to use in the frontend, if any."""
-        return ICON_ALARMS
-
-
-class GoogleHomeNextAlarmEntity(CoordinatorEntity):
-    """Entity base for next alarm sensor"""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
-        super().__init__(coordinator)
-        self.device_name = device_name
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return {
-            "identifiers": {(DOMAIN, self.device_name)},
-            "name": f"{DEFAULT_NAME} {self.device_name}",
-            "model": VERSION,
-            "manufacturer": MANUFACTURER,
-        }
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_NEXT_ALARM}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_NEXT_ALARM}"
-
-    @property
-    def icon(self) -> str:
-        """Icon to use in the frontend, if any."""
-        return ICON_ALARMS
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class of the sensor."""
-        return DEVICE_CLASS_TIMESTAMP
-
-
-class GoogleHomeTimersEntity(CoordinatorEntity):
-    """Entity base for timers sensor"""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
-        super().__init__(coordinator)
-        self.device_name = device_name
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_TIMERS}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return {
-            "identifiers": {(DOMAIN, self.device_name)},
-            "name": f"{DEFAULT_NAME} {self.device_name}",
-            "model": VERSION,
-            "manufacturer": MANUFACTURER,
-        }
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_TIMERS}"
-
-    @property
-    def icon(self) -> str:
-        """Icon to use in the frontend, if any."""
-        return ICON_TIMERS
-
-
-class GoogleHomeNextTimerEntity(CoordinatorEntity):
-    """Entity base for next timer sensor"""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
-        super().__init__(coordinator)
-        self.device_name = device_name
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return {
-            "identifiers": {(DOMAIN, self.device_name)},
-            "name": f"{DEFAULT_NAME} {self.device_name}",
-            "model": VERSION,
-            "manufacturer": MANUFACTURER,
-        }
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_NEXT_TIMER}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_NEXT_TIMER}"
-
-    @property
-    def icon(self) -> str:
-        """Icon to use in the frontend, if any."""
-        return ICON_TIMERS
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class of the sensor."""
-        return DEVICE_CLASS_TIMESTAMP
+    @staticmethod
+    def as_dict(obj_list: List[Any]) -> List[Dict[Any, Any]]:
+        """Return list of objects represented as dictionaries """
+        return [obj.__dict__ for obj in obj_list]

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -28,7 +28,7 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
 
     @property
     @abstractmethod
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         ...
 

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -54,7 +54,9 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
         """Return the device matched by device name
         from the list of google devices in coordinator_data"""
         matched_devices = [
-            device for device in self.coordinator if device.name == self.device_name
+            device
+            for device in self.coordinator.data
+            if device.name == self.device_name
         ]
         return matched_devices[0] if matched_devices else None
 

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -1,5 +1,6 @@
 """Defines base entities for Google Home"""
 
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Set, Tuple, TypedDict
 
 from homeassistant.helpers.update_coordinator import (
@@ -18,12 +19,28 @@ class DeviceInfo(TypedDict):
     manufacturer: str
 
 
-class GoogleHomeBaseEntity(CoordinatorEntity):
+class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
     """Base entity base for Google Home sensors"""
 
     def __init__(self, coordinator: DataUpdateCoordinator, device_name: str):
         super().__init__(coordinator)
         self.device_name = device_name
+
+    @property
+    @abstractmethod
+    def label(self):
+        """Label to use for name and unique id."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return f"{self.device_name} {self.label}"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID to use for this entity."""
+        return f"{self.device_name}/{self.label}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -36,14 +53,10 @@ class GoogleHomeBaseEntity(CoordinatorEntity):
     def get_device(self):
         """Return the device matched by device name
         from the list of google devices in coordinator_data"""
-        return next(
-            (
-                device
-                for device in self.coordinator.data
-                if device.name == self.device_name
-            ),
-            None,
-        )
+        matched_devices = [
+            device for device in self.coordinator if device.name == self.device_name
+        ]
+        return matched_devices[0] if matched_devices else None
 
     @staticmethod
     def as_dict(obj_list: List[Any]) -> List[Dict[Any, Any]]:

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -74,14 +74,9 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
     """Google Home Device sensor."""
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_DEVICE}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_DEVICE}"
+    def label(self):
+        """Label to use for name and unique id."""
+        return LABEL_DEVICE
 
     @property
     def icon(self) -> str:
@@ -125,14 +120,9 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
     """Google Home Alarms sensor."""
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_ALARMS}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_ALARMS}"
+    def label(self):
+        """Label to use for name and unique id."""
+        return LABEL_ALARMS
 
     @property
     def icon(self) -> str:
@@ -163,14 +153,9 @@ class GoogleHomeNextAlarmSensor(GoogleHomeBaseEntity):
     """Google Home Next Alarm sensor."""
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_NEXT_ALARM}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_NEXT_ALARM}"
+    def label(self):
+        """Label to use for name and unique id."""
+        return LABEL_NEXT_ALARM
 
     @property
     def icon(self) -> str:
@@ -210,14 +195,9 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
     """Google Home Timers sensor."""
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_TIMERS}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_TIMERS}"
+    def label(self):
+        """Label to use for name and unique id."""
+        return LABEL_TIMERS
 
     @property
     def icon(self) -> str:
@@ -247,14 +227,9 @@ class GoogleHomeNextTimerSensor(GoogleHomeBaseEntity):
     """Google Home Next Timer sensor."""
 
     @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return f"{self.device_name} {LABEL_NEXT_TIMER}"
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{LABEL_NEXT_TIMER}"
+    def label(self):
+        """Label to use for name and unique id."""
+        return LABEL_NEXT_TIMER
 
     @property
     def icon(self) -> str:

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -74,7 +74,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
     """Google Home Device sensor."""
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         return LABEL_DEVICE
 
@@ -120,7 +120,7 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
     """Google Home Alarms sensor."""
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         return LABEL_ALARMS
 
@@ -153,7 +153,7 @@ class GoogleHomeNextAlarmSensor(GoogleHomeBaseEntity):
     """Google Home Next Alarm sensor."""
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         return LABEL_NEXT_ALARM
 
@@ -195,7 +195,7 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
     """Google Home Timers sensor."""
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         return LABEL_TIMERS
 
@@ -227,7 +227,7 @@ class GoogleHomeNextTimerSensor(GoogleHomeBaseEntity):
     """Google Home Next Timer sensor."""
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Label to use for name and unique id."""
         return LABEL_NEXT_TIMER
 


### PR DESCRIPTION
Simplify class structure.
- One base class for common code, remove mixin.
- All specialisation is done on sensor level.
- Remove `model` with invalid `VERSION` for `device_info`. We don't really want to maintain version in different places.
- Make `GoogleHomeDeviceSensor` constructor the same as for other sensors. If there is no such device in `coordinator_data`, set state to `None`, it should render as `unknown` in HA.
- Rename `GoogleHomeAlarmSensor` to `GoogleHomeAlarmsSensor`, same for `Timers`.
- Delete non existing device class for `GoogleHomeDeviceSensor`.
- Update docstrings.