### PR TITLE
Combine two sensors into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,41 +52,18 @@ tokens and use those tokens making API calls to Google Home devices.
 
 This component will set up the following platforms:
 
-| Platform | Sample sensor                   | Description                                               |
-| -------- | ------------------------------- | --------------------------------------------------------- |
-| `sensor` | `sensor.living_room_timers`     | Sensor with a list of timers from the device              |
-| `sensor` | `sensor.living_room_next_timer` | Sensor with next timer from the device                    |
-| `sensor` | `sensor.living_room_alarms`     | Sensor with a list of alarms from the device              |
-| `sensor` | `sensor.living_room_next_alarm` | Sensor with next alarm from the device                    |
-| `sensor` | `sensor.living_room_token`      | Sensor with the local authentication token for the device |
-
-### Timers
-
-You can have multiple timers on your Google Home device. The Home Assistant
-timers sensor will represent all of them in the state attributes as a list "timers".
-Each of timers has the following keys:
-
-| Key              | Value type                   | Description                                                               |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `id`             | Google Home corresponding ID | Used to delete/modify timer                                               |
-| `label`          | Name                         | Name of the timer, this can be set when making the timer                  |
-| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off         |
-| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
-| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
-| `duration`       | Seconds                      | Timer duration in seconds                                                 |
-
-### Next timer
-
-Will always show the next timer as timestring (ie: `2021-03-07T15:26:17+01:00`) if there is one set, else it will show off.
-
-Has the same attributes as `sensor.living_room_timers`, but only for the first timer.
+| Platform | Sample sensor               | Description                                               |
+| -------- | --------------------------- | --------------------------------------------------------- |
+| `sensor` | `sensor.living_room_alarms` | Sensor with a list of alarms from the device              |
+| `sensor` | `sensor.living_room_timers` | Sensor with a list of timers from the device              |
+| `sensor` | `sensor.living_room_token`  | Sensor with the local authentication token for the device |
 
 ### Alarms
 
-You can have multiple alarms on your Google Home device. The Home Assistant
+You can have multiple alarms on your Google Home device. Home Assistant
 alarms sensor will represent all of them in the state attributes as a list
-"alarms".
-Each of alarms has the following keys:
+`alarms`.
+Each of the alarms has the following keys:
 
 | Key              | Value type                   | Description                                                                                                                                                                                             |
 | ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -97,13 +74,26 @@ Each of alarms has the following keys:
 | `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                                                                                                                                                  |
 | `recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
 
-### Next alarm
+The state value shows the next alarm as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one alarm set, otherwise it is set to `off`.
 
-Will always show the next alarm as timestring (ie: `2021-03-07T15:26:17+01:00`) if there is one set, else it will show off.
+This sensor is formatted to be compatible with the mobile app sensor, e.g. `sensor.phone_next_alarm`.
 
-This sensor is formatted to have compatibly with the sensor that mobile app has `sensor.phone_next_alarm`.
+### Timers
 
-Has the same attributes as `sensor.living_room_alarms`, but only for the first alarm.
+You can have multiple timers on your Google Home device. Home Assistant
+timers sensor will represent all of them in the state attributes as a list `timers`.
+Each of the timers has the following keys:
+
+| Key              | Value type                   | Description                                                               |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `id`             | Google Home corresponding ID | Used to delete/modify timer                                               |
+| `label`          | Name                         | Name of the timer, this can be set when making the timer                  |
+| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off         |
+| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
+| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
+| `duration`       | Seconds                      | Timer duration in seconds                                                 |
+
+The state value shows the next timer as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one timer set, otherwise it is set to `off`.
 
 ## Getting Started
 

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -33,8 +33,6 @@ DEFAULT_NAME = "Google Home"
 
 LABEL_ALARMS = "alarms"
 LABEL_AVAILABLE = "available"
-LABEL_NEXT_ALARM = "next_alarm"
-LABEL_NEXT_TIMER = "next_timer"
 LABEL_TIMERS = "timers"
 LABEL_DEVICE = "device"
 


### PR DESCRIPTION
State of alarms is now the next alarm. Same for timers. Set device class to `timestamp`.

Also if `device` is `None`, set state and attributes to some value instead of throwing an error (Fixes #97).

Update documentation and move alarms on the top, I think they're used more often.

Tested locally.

Closes #106 