### PR TITLE
Add support for the status attribute of alarms/timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Each of the alarms has the following keys:
 | `fire_time`      | Seconds                      | Raw value coming from Google Home device until the alarm goes off                                                                                                                                       |
 | `local_time`     | Time                         | Time when the alarm goes off, in respect to the Home Assistant's timezone                                                                                                                               |
 | `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                                                                                                                                                  |
+| `status`         | Status (string)              | The current status of the alarm, either `none`, `set`, `ringing` or `snoozed`                                                                                                                           |
 | `recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
 
 The state value shows the next alarm as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one alarm set, otherwise it is set to `unavailable`.
@@ -89,8 +90,22 @@ Each of the timers has the following keys:
 | `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
 | `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
 | `duration`       | Seconds                      | Timer duration in seconds                                                 |
+| `status`         | Status (string)              | The current status of the timer, either `none`, `set`, or `ringing`       |
 
 The state value shows the next timer as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one timer set, otherwise it is set to `unavailable`.
+
+### Alarm/Timer status
+
+Both alarms and timers have a property called status. The status of the next alarm/timer (which is used as sensor state value) is also available through sensor state attributes `next_alarm_status` and `next_timer_status` respectively.
+
+| Status    | Meaning                                                            |
+| --------- | ------------------------------------------------------------------ |
+| `none`    | Alarm or timer does not exist                                      |
+| `set`     | Alarm or timer has been set                                        |
+| `ringing` | Alarm or timer is ringing right now                                |
+| `snoozed` | Alarm was ringing and has been snoozed (only available for alarms) |
+
+Note that timers lack the additional `snoozed` state due to a limitation of the API. If you actually snooze a timer it will just reset itself to the state `set` again.
 
 ## Getting Started
 

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -16,7 +16,13 @@ from .const import (
     LABEL_TIMERS,
 )
 from .entity import GoogleHomeBaseEntity
-from .models import GoogleHomeAlarmDict, GoogleHomeDevice, GoogleHomeTimerDict
+from .models import (
+    GoogleHomeAlarmDict,
+    GoogleHomeAlarmStatus,
+    GoogleHomeDevice,
+    GoogleHomeTimerDict,
+    GoogleHomeTimerStatus,
+)
 from .types import (
     AddEntitiesCallback,
     AlarmsAttributes,
@@ -130,9 +136,20 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
     def device_state_attributes(self) -> AlarmsAttributes:
         """Return the state attributes."""
         return {
+            "next_alarm_status": self._get_next_alarm_status(),
             "alarms": self._get_alarms_data(),
             "integration": DOMAIN,
         }
+
+    def _get_next_alarm_status(self) -> str:
+        """Update next alarm status from coordinator"""
+        device = self.get_device()
+        next_alarm = device.get_next_alarm() if device else None
+        return (
+            next_alarm.status.name.lower()
+            if next_alarm
+            else GoogleHomeAlarmStatus.NONE.name.lower()
+        )
 
     def _get_alarms_data(self) -> List[GoogleHomeAlarmDict]:
         """Update alarms data extracting it from coordinator"""
@@ -172,9 +189,20 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
     def device_state_attributes(self) -> TimersAttributes:
         """Return the state attributes."""
         return {
+            "next_timer_status": self._get_next_timer_status(),
             "timers": self._get_timers_data(),
             "integration": DOMAIN,
         }
+
+    def _get_next_timer_status(self) -> str:
+        """Update next timer status from coordinator"""
+        device = self.get_device()
+        next_timer = device.get_next_timer() if device else None
+        return (
+            next_timer.status.name.lower()
+            if next_timer
+            else GoogleHomeTimerStatus.NONE.name.lower()
+        )
 
     def _get_timers_data(self) -> List[GoogleHomeTimerDict]:
         """Update timers data extracting it from coordinator"""

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -20,6 +20,7 @@ class AlarmJsonDict(TypedDict, total=False):
 
     id: str
     fire_time: int
+    status: int
     label: Optional[str]
     recurrence: Optional[str]
 
@@ -30,6 +31,7 @@ class TimerJsonDict(TypedDict, total=False):
     id: str
     fire_time: int
     original_duration: int
+    status: int
     label: Optional[str]
 
 
@@ -38,16 +40,18 @@ class GoogleHomeAlarmDict(TypedDict):
 
     alarm_id: str
     fire_time: int
+    status: str
     label: Optional[str]
     recurrence: Optional[str]
 
 
 class GoogleHomeTimerDict(TypedDict):
-    """Typed dict representation of Google Home time"""
+    """Typed dict representation of Google Home timer"""
 
     timer_id: str
     fire_time: int
     duration: str
+    status: str
     label: Optional[str]
 
 
@@ -65,6 +69,7 @@ class DeviceAttributes(TypedDict):
 class AlarmsAttributes(TypedDict):
     """Typed dict for alarms attributes"""
 
+    next_alarm_status: str
     alarms: List[GoogleHomeAlarmDict]
     integration: str
 
@@ -72,6 +77,7 @@ class AlarmsAttributes(TypedDict):
 class TimersAttributes(TypedDict):
     """Typed dict for timers attributes"""
 
+    next_timer_status: str
     timers: List[GoogleHomeTimerDict]
     integration: str
 


### PR DESCRIPTION
First of all, thank you guys for working on this. The integration works perfectly for me ❤️ 

I have implemented support for the status attribute (set/ringing/snoozed) for alarms/timers, as I have used this for automations with a different integration before.

From https://rithvikvibhu.github.io/GHLocalApi/#operation/GetAlarmsandTimers:

* Alarms: status is 1 for set up and 2 for ringing. (3 is snoozed, found that out by trial and error 😅 )
* Timers: status is 1 for set up and 3 for ringing.


I have also added the status of the next alarm as a first level state attribute "status" for easier access.
Let me know, what you think :) 
