### PR TITLE
Adding ClientConnectionError handler

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -143,6 +143,7 @@ class GlocaltokensApiClient:
                     # We need to retry the update task instead of just cleaning the list
                     self.google_devices = []
                 elif response.status == HTTP_NOT_FOUND:
+                    device.available = False
                     _LOGGER.debug(
                         (
                             "Failed to fetch data from %s, API returned %d. "

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -147,9 +147,8 @@ class GlocaltokensApiClient:
                     _LOGGER.debug(
                         (
                             "Failed to fetch data from %s, API returned %d. "
-                            "The device(hardware='%s') is possibly not Google Home "
-                            "compatable and has no alarms/timers. "
-                            "Will retry later."
+                            "The device(hardware='%s') is not Google Home "
+                            "compatable and has no alarms/timers."
                         ),
                         device.name,
                         response.status,

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -3,7 +3,8 @@ from asyncio import gather
 import logging
 from typing import List, Optional
 
-import aiohttp
+from aiohttp import ClientError, ClientSession
+from aiohttp.client_exceptions import ClientConnectorError
 from glocaltokens.client import Device, GLocalAuthenticationTokens
 from glocaltokens.utils.token import is_aas_et
 from zeroconf import Zeroconf
@@ -33,7 +34,7 @@ class GlocaltokensApiClient:
     def __init__(
         self,
         hass: HomeAssistant,
-        session: aiohttp.ClientSession,
+        session: ClientSession,
         username: Optional[str] = None,
         password: Optional[str] = None,
         master_token: Optional[str] = None,
@@ -142,12 +143,12 @@ class GlocaltokensApiClient:
                     # We need to retry the update task instead of just cleaning the list
                     self.google_devices = []
                 elif response.status == HTTP_NOT_FOUND:
-                    device.available = False
                     _LOGGER.debug(
                         (
                             "Failed to fetch data from %s, API returned %d. "
-                            "The device(hardware='%s') is not Google Home "
-                            "compatable and has no alarms/timers."
+                            "The device(hardware='%s') is possibly not Google Home "
+                            "compatable and has no alarms/timers. "
+                            "Will retry later."
                         ),
                         device.name,
                         response.status,
@@ -160,7 +161,16 @@ class GlocaltokensApiClient:
                         response.status,
                         response,
                     )
-        except aiohttp.ClientError as ex:
+        except ClientConnectorError:
+            # Check if this is where we are getting with incorrect token
+            _LOGGER.debug(
+                (
+                    "Failed to connect to %s device. "
+                    "The device is probably offline. Will retry later."
+                ),
+                device.name,
+            )
+        except ClientError as ex:
             # Make sure that we log the exception if one occurred.
             # The only reason we do this broad is so we easily can
             # debug the application.


### PR DESCRIPTION
Closes #128,

We should not flood HA logs with errors if we can't connect to the device (happens when some devices go offline). Therefore let's catch the ConnectionError and log as `debug`.

I have tested locally by fetching data from device and then unplugging it