### PR TITLE
Fix Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
-test:
-  - tests/*
+dependencies:
+  - poetry.lock
 
-github_structure:
+documentation:
+  - "*.md"
+
+github structure:
   - .github/*

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -8,6 +8,10 @@
   description: Something isn't working
   color: d73a4a
 
+- name: dependencies
+  description: Pull requests that update a dependency file
+  color: 0366d6
+
 - name: documentation
   description: Improvements or additions to documentation
   color: 0075ca
@@ -20,7 +24,7 @@
   description: New feature or request
   color: a2eeef
 
-- name: github_structure
+- name: github structure
   description: Pull requests that update Github actions/workflow code
   color: "000000"
 
@@ -35,6 +39,18 @@
 - name: invalid
   description: This doesn't seem right
   color: e4e669
+
+- name: major
+  description: Major changes. Used for release bump
+  color: 16970B
+
+- name: minor
+  description: Minor changes. Used for release bump
+  color: 16970B
+
+- name: patch
+  description: Patch changes. Used for release bump
+  color: 16970B
 
 - name: performance
   description: Performance
@@ -59,15 +75,3 @@
 - name: wontfix
   description: This will not be worked on
   color: ffffff
-
-- name: major
-  description: Major changes. Used for release bump
-  color: 16970B
-
-- name: minor
-  description: minor changes. Used for release bump
-  color: 16970B
-
-- name: patch
-  description: Patch changes. Used for release bump
-  color: 16970B

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,7 @@ categories:
       - "documentation"
   - title: "🔧 Internal structure enhancement"
     labels:
+      - "github structure"
       - "refactoring"
       - "removal"
   - title: "🧰 Maintenance"

--- a/.github/workflows/home-assistant.yml
+++ b/.github/workflows/home-assistant.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - dev
   pull_request:
 
 env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,20 +1,16 @@
-name: Manage labels
+name: Labeler
 
 on:
   pull_request_target:
     branches:
-      - dev
       - master
 
 jobs:
-  labeler:
-    name: Labeler
+  triage:
+    name: Triage
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
-
-      - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v3.1.0
+      - name: Run Pull Request Labeler
+        uses: actions/labeler@main
         with:
-          skip-delete: true
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - dev
   pull_request:
 
 jobs:

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,17 @@
+name: Manage labels
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  labeler:
+    name: Update labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run Labeler
+        uses: crazy-max/ghaction-github-labeler@v3.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,10 @@
 name: Draft a release note
+
 on:
   push:
     branches:
-      - dev
       - master
+
 jobs:
   draft_release:
     name: Release Drafter


### PR DESCRIPTION
- https://github.com/crazy-max/ghaction-github-labeler keeps labels from `labels.yml` in sync with Github. It should run on push.
- https://github.com/actions/labeler assigns labels based on `labeler.yml` config. It wasn't running.
- Updated `labels.yml`.
- Added few more rules in `labeler.yml`.
- Remove `skip-delete: true`. New labels should be added in `labels.yml`.
- Removed `dev` branch from Github Actions because it doesn't exist.