### PR TITLE
Complete strict type checks

### DIFF
--- a/custom_components/google_home/__init__.py
+++ b/custom_components/google_home/__init__.py
@@ -32,7 +32,11 @@ from .const import (
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-async def async_setup(_hass: HomeAssistant, _config: dict) -> bool:
+# Remove after updating to 2021.4.0
+async def async_setup(
+    _hass: HomeAssistant,
+    _config: dict,  # type: ignore[type-arg]
+) -> bool:
     """Set up this integration using YAML is not supported."""
     return True
 

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -34,13 +34,13 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self.errors: Dict[str, str] = {}
+        self._errors: Dict[str, str] = {}
 
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
-        self.errors = {}
+        self._errors = {}
 
         # Only a single instance of the integration is allowed:
         if self._async_current_entries():
@@ -65,7 +65,7 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 )
                 return self.async_create_entry(title=username, data=user_input)
-            self.errors["base"] = "auth"
+            self._errors["base"] = "auth"
             return await self._show_config_form(user_input)
 
         return await self._show_config_form(user_input)
@@ -89,7 +89,7 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
-            errors=self.errors,
+            errors=self._errors,
         )
 
     async def _test_credentials(self, client: GlocaltokensApiClient) -> Optional[str]:

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -34,11 +34,13 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self._errors: Dict[str, str] = {}
+        self.errors: Dict[str, str] = {}
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
-        self._errors = {}
+        self.errors = {}
 
         # Only a single instance of the integration is allowed:
         if self._async_current_entries():
@@ -63,7 +65,7 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 )
                 return self.async_create_entry(title=username, data=user_input)
-            self._errors["base"] = "auth"
+            self.errors["base"] = "auth"
             return await self._show_config_form(user_input)
 
         return await self._show_config_form(user_input)
@@ -75,7 +77,9 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> GoogleHomeOptionsFlowHandler:
         return GoogleHomeOptionsFlowHandler(config_entry)
 
-    async def _show_config_form(self, _user_input):
+    async def _show_config_form(
+        self, _user_input: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """Show the configuration form to edit location data."""
         return self.async_show_form(
             step_id="user",
@@ -85,10 +89,10 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
-            errors=self._errors,
+            errors=self.errors,
         )
 
-    async def _test_credentials(self, client) -> Optional[str]:
+    async def _test_credentials(self, client: GlocaltokensApiClient) -> Optional[str]:
         """Returns true and master token if credentials are valid."""
         try:
             master_token = await client.async_get_master_token()
@@ -106,11 +110,15 @@ class GoogleHomeOptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry = config_entry
         self.options = dict(config_entry.options)
 
-    async def async_step_init(self, _user_input=None):
+    async def async_step_init(
+        self, _user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Manage the options."""
         return await self.async_step_user()
 
-    async def async_step_user(self, user_input=None) -> Dict[str, Any]:
+    async def async_step_user(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
         if user_input is not None:
             self.options.update(user_input)
@@ -125,7 +133,7 @@ class GoogleHomeOptionsFlowHandler(config_entries.OptionsFlow):
             ),
         )
 
-    async def _update_options(self):
+    async def _update_options(self) -> Dict[str, Any]:
         """Update config entry options."""
         return self.async_create_entry(
             title=self.config_entry.data.get(CONF_USERNAME), data=self.options

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -1,6 +1,7 @@
 """Defines base entities for Google Home"""
 
 from abc import ABC, abstractmethod
+from typing import List, Optional
 
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -50,10 +51,10 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
             "manufacturer": MANUFACTURER,
         }
 
-    def get_device(self) -> GoogleHomeDevice:
+    def get_device(self) -> Optional[GoogleHomeDevice]:
         """Return the device matched by device name
         from the list of google devices in coordinator_data"""
-        matched_devices = [
+        matched_devices: List[GoogleHomeDevice] = [
             device
             for device in self.coordinator.data
             if device.name == self.device_name

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -27,14 +27,14 @@ from .const import (
     SERVICE_DELETE_TIMER,
 )
 from .entity import GoogleHomeBaseEntity
-from .models import (
+from .models import GoogleHomeAlarmStatus, GoogleHomeDevice, GoogleHomeTimerStatus
+from .types import (
+    AlarmsAttributes,
+    DeviceAttributes,
     GoogleHomeAlarmDict,
-    GoogleHomeAlarmStatus,
-    GoogleHomeDevice,
     GoogleHomeTimerDict,
-    GoogleHomeTimerStatus,
+    TimersAttributes,
 )
-from .types import AlarmsAttributes, DeviceAttributes, TimersAttributes
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -195,6 +195,10 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
         """Service call to delete alarm on device"""
         device = self.get_device()
 
+        if device is None:
+            _LOGGER.error("Device %s is not found.", self.device_name)
+            return
+
         if not self.is_valid_alarm_id(alarm_id):
             _LOGGER.error(
                 "Incorrect ID format! Please provide a valid alarm ID. "
@@ -267,6 +271,10 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
     async def async_delete_timer(self, timer_id: str) -> None:
         """Service call to delete alarm on device"""
         device = self.get_device()
+
+        if device is None:
+            _LOGGER.error("Device %s is not found.", self.device_name)
+            return
 
         if not self.is_valid_timer_id(timer_id):
             _LOGGER.error(

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,28 +17,15 @@ ignore =
 
 [mypy]
 python_version = 3.8
-check_untyped_defs = True
-# disallow_any_explicit = True
-# disallow_any_unimported = True
-# disallow_subclassing_any = True
-disallow_incomplete_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-disallow_untyped_defs = True
-no_implicit_optional = True
+strict = True
+disallow_any_explicit = True
+disallow_any_unimported = True
 show_none_errors = True
 warn_no_return = True
-warn_redundant_casts = True
-# warn_return_any = True
 warn_unreachable = True
-warn_unused_ignores = True
 
 [mypy-google_home.config_flow]
 disallow_any_explicit = False
-disallow_incomplete_defs = False
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-disallow_untyped_defs = False
 
 [mypy-voluptuous.*]
 ignore_missing_imports = True


### PR DESCRIPTION
- Add missing type hints in `config_flow`. Unfortunately, we still have to use `Any` there.
- Fixed implicit re-export. Now mypy will run this check.
- Found bug with unchecked `None` in `async_delete_alarm`.

Closes #85 