### PR TITLE
Improve typing in config flow

### DIFF
--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     DOMAIN,
 )
 from .exceptions import InvalidMasterToken
+from .types import OptionsFlowDict
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -57,17 +58,10 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
             master_token = await self._test_credentials(client)
             if master_token is not None:
-                data = user_input
-                data.update(
-                    {
-                        CONF_MASTER_TOKEN: master_token,
-                        CONF_ANDROID_ID: await client.get_android_id(),
-                    }
-                )
+                user_input[CONF_MASTER_TOKEN] = master_token
+                user_input[CONF_ANDROID_ID] = await client.get_android_id()
                 return self.async_create_entry(title=username, data=user_input)
             self._errors["base"] = "auth"
-            return await self._show_config_form(user_input)
-
         return await self._show_config_form(user_input)
 
     @staticmethod
@@ -106,18 +100,18 @@ class GoogleHomeOptionsFlowHandler(config_entries.OptionsFlow):
     """Config flow options handler for GoogleHome."""
 
     def __init__(self, config_entry: ConfigEntry):
-        """Initialize HACS options flow."""
+        """Initialize options flow."""
         self.config_entry = config_entry
-        self.options = dict(config_entry.options)
+        self.options = config_entry.options
 
     async def async_step_init(
-        self, _user_input: Optional[Dict[str, Any]] = None
+        self, _user_input: Optional[OptionsFlowDict] = None
     ) -> Dict[str, Any]:
         """Manage the options."""
         return await self.async_step_user()
 
     async def async_step_user(
-        self, user_input: Optional[Dict[str, Any]] = None
+        self, user_input: Optional[OptionsFlowDict] = None
     ) -> Dict[str, Any]:
         """Handle a flow initialized by the user."""
         if user_input is not None:

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -75,3 +75,9 @@ class DeviceInfo(TypedDict):
     identifiers: Set[Tuple[str, str]]
     name: str
     manufacturer: str
+
+
+class OptionsFlowDict(TypedDict):
+    """Typed dict for options flow handler"""
+
+    data_collection: bool


### PR DESCRIPTION
I was looking at removing `Dict[str, Any]` in config flow and this is as far as we can go now. Other places require changing HA API, I'll try to do this at some point.

But also I found some small issues here:
- `data = user_input` created new reference to the same dict and it was updated while the original reference was passed to the `async_create_entry`. It was working as expected but I don't get why we need to do that is such way.