### PR TITLE
Add do not disturb switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tokens and use those tokens making API calls to Google Home devices.
 
 ## Sensors
 
-This component will set up the following platforms:
+This component will set up the following sensors:
 
 | Platform | Sample sensor               | Description                                               |
 | -------- | --------------------------- | --------------------------------------------------------- |
@@ -105,6 +105,14 @@ Both alarms and timers have a property called status. The status of the next ala
 | `snoozed` | Alarm was ringing and has been snoozed (only available for alarms) |
 
 Note that timers lack the additional `snoozed` state due to a limitation of the API. If you actually snooze a timer it will just reset itself to the state `set` again.
+
+## Switches
+
+This component will set up the following switches:
+
+| Platform | Sample sensor                  | Description                                         |
+| -------- | ------------------------------ | --------------------------------------------------- |
+| `sensor` | `switch.living_do_not_disturb` | Toggles Do Not Disturb mode on a Google Home device |
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@
 
 1. [About The Project](#about)
 2. [Sensors](#sensors)
-3. [Services](#services)
-4. [Getting Started](#getting-started)
+3. [Switches](#switches)
+4. [Services](#services)
+5. [Getting Started](#getting-started)
    - [Prerequisites](#prerequisites)
    - [HACS Installation](#hacs-installation)
    - [Manual Installation](#manual-installation)
    - [Integration Setup](#integration-setup)
    - [Running in Home Assistant Docker container](#running-in-home-assistant-docker-container)
-5. [Lovelace Cards](#lovelace-cards)
-6. [Diagnostic Data Collection](#diagnostic-data-collection)
-7. [Troubleshooting](#troubleshooting)
-8. [Contribution](#contribution)
-9. [Credits](#credits)
+6. [Lovelace Cards](#lovelace-cards)
+7. [Diagnostic Data Collection](#diagnostic-data-collection)
+8. [Troubleshooting](#troubleshooting)
+9. [Contribution](#contribution)
+10. [Credits](#credits)
 
 </details>
 
@@ -110,9 +111,9 @@ Note that timers lack the additional `snoozed` state due to a limitation of the 
 
 This component will set up the following switches:
 
-| Platform | Sample switch                  | Description                                         |
-| -------- | ------------------------------ | --------------------------------------------------- |
-| `sensor` | `switch.living_do_not_disturb` | Toggles Do Not Disturb mode on a Google Home device |
+| Platform | Sample switch                  | Description                                        |
+| -------- | ------------------------------ | -------------------------------------------------- |
+| `switch` | `switch.living_do_not_disturb` | Toggle Do Not Disturb mode on a Google Home device |
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Note that timers lack the additional `snoozed` state due to a limitation of the 
 
 This component will set up the following switches:
 
-| Platform | Sample sensor                  | Description                                         |
+| Platform | Sample switch                  | Description                                         |
 | -------- | ------------------------------ | --------------------------------------------------- |
 | `sensor` | `switch.living_do_not_disturb` | Toggles Do Not Disturb mode on a Google Home device |
 

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -214,7 +214,7 @@ class GlocaltokensApiClient:
     async def collect_data_from_endpoints(
         self, device: GoogleHomeDevice, ip_address: str, auth_token: str
     ) -> GoogleHomeDevice:
-        """Collects data from different endpoints."""
+        """Collect data from different endpoints."""
 
         # This could properly be down in a better and cleaner way.
         device = await self.get_alarms_and_timers(device, ip_address, auth_token)

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -90,7 +90,7 @@ class GlocaltokensApiClient:
                 GoogleHomeDevice(
                     name=device.device_name,
                     auth_token=device.local_auth_token,
-                    ip_address=device.ip_address,
+                    ip_address=device.ip,
                     hardware=device.hardware,
                 )
                 for device in google_devices
@@ -216,6 +216,7 @@ class GlocaltokensApiClient:
     ) -> GoogleHomeDevice:
         """Collects data from different endpoints."""
 
+        # This could properly be down in a better and cleaner way.
         device = await self.get_alarms_and_timers(device, ip_address, auth_token)
 
         device = await self.get_or_set_do_not_disturb(device)
@@ -340,13 +341,13 @@ class GlocaltokensApiClient:
         elif enable:
             data = {"notifications_enabled": False}
             _LOGGER.debug(
-                "Setting Do Not Disturb setting to True on Google Home device %s",
+                "Setting Do Not Disturb setting to False on Google Home device %s",
                 device.name,
             )
         elif enable is False:
             data = {"notifications_enabled": True}
             _LOGGER.debug(
-                "Setting Do Not Disturb setting to False on Google Home device %s",
+                "Setting Do Not Disturb setting to True on Google Home device %s",
                 device.name,
             )
 

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -338,13 +338,13 @@ class GlocaltokensApiClient:
                 device.name,
             )
         elif enable:
-            data = {"notifications_enabled": True}
+            data = {"notifications_enabled": False}
             _LOGGER.debug(
                 "Setting Do Not Disturb setting to True on Google Home device %s",
                 device.name,
             )
         elif enable is False:
-            data = {"notifications_enabled": False}
+            data = {"notifications_enabled": True}
             _LOGGER.debug(
                 "Setting Do Not Disturb setting to False on Google Home device %s",
                 device.name,
@@ -364,12 +364,12 @@ class GlocaltokensApiClient:
                 )
 
                 device.set_do_not_disturb_status(is_enabled)
-
-            _LOGGER.debug(
-                "Response not expected from Google Home device %s - %s",
-                device.name,
-                response,
-            )
+            else:
+                _LOGGER.debug(
+                    "Response not expected from Google Home device %s - %s",
+                    device.name,
+                    response,
+                )
 
         return device
 
@@ -408,6 +408,18 @@ class GlocaltokensApiClient:
                         resp = await response.json()
                     except ContentTypeError:
                         resp = True
+                elif response.status == HTTP_NOT_FOUND:
+                    _LOGGER.debug(
+                        (
+                            "Failed to post data to %s, API returned %d. "
+                            "The device(hardware='%s') is possibly not Google Home "
+                            "compatible and has no alarms/timers. "
+                            "Will retry later."
+                        ),
+                        device.name,
+                        response.status,
+                        device.hardware,
+                    )
                 else:
                     _LOGGER.error(
                         "Failed to access %s, API returned" " %d: %s",

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -364,7 +364,7 @@ class GlocaltokensApiClient:
                     is_enabled,
                 )
 
-                device.set_do_not_disturb_status(is_enabled)
+                device.set_do_not_disturb_status(bool(is_enabled))
             else:
                 _LOGGER.debug(
                     "Response not expected from Google Home device %s - %s",

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -90,7 +90,7 @@ class GlocaltokensApiClient:
                 GoogleHomeDevice(
                     name=device.device_name,
                     auth_token=device.local_auth_token,
-                    ip_address=device.ip,
+                    ip_address=device.ip_address,
                     hardware=device.hardware,
                 )
                 for device in google_devices

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -20,13 +20,15 @@ ALARM_AND_TIMER_ID_LENGTH = 42
 ICON_TOKEN = "mdi:form-textbox-password"
 ICON_ALARMS = "mdi:alarm-multiple"
 ICON_TIMERS = "mdi:timer-sand"
+ICON_DO_NOT_DISTURB = "mdi:minus-circle"
 
 # Device classes
 BINARY_SENSOR_DEVICE_CLASS = "connectivity"
 
 # Platforms
 SENSOR = "sensor"
-PLATFORMS = [SENSOR]
+SWITCH = "switch"
+PLATFORMS = [SENSOR, SWITCH]
 
 # Services
 SERVICE_REBOOT = "reboot_device"
@@ -48,6 +50,7 @@ LABEL_ALARMS = "alarms"
 LABEL_AVAILABLE = "available"
 LABEL_TIMERS = "timers"
 LABEL_DEVICE = "device"
+LABEL_DO_NOT_DISTURB = "do_not_disturb"
 
 # DEVICE PORT
 PORT = 8443
@@ -56,6 +59,7 @@ PORT = 8443
 API_ENDPOINT_ALARMS = "setup/assistant/alarms"
 API_ENDPOINT_DELETE = "setup/assistant/alarms/delete"
 API_ENDPOINT_REBOOT = "setup/reboot"
+API_ENDPOINT_DO_NOT_DISTURB = "setup/assistant/notifications"
 HEADER_CAST_LOCAL_AUTH = "cast-local-authorization-token"
 HEADER_CONTENT_TYPE = "content-type"
 

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -50,7 +50,7 @@ LABEL_ALARMS = "alarms"
 LABEL_AVAILABLE = "available"
 LABEL_TIMERS = "timers"
 LABEL_DEVICE = "device"
-LABEL_DO_NOT_DISTURB = "do_not_disturb"
+LABEL_DO_NOT_DISTURB = "Do Not Disturb"
 
 # DEVICE PORT
 PORT = 8443

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -37,6 +37,7 @@ class GoogleHomeDevice:
         self.ip_address = ip_address
         self.hardware = hardware
         self.available = True
+        self.do_not_disturb = False
         self._timers: List[GoogleHomeTimer] = []
         self._alarms: List[GoogleHomeAlarm] = []
 
@@ -83,6 +84,14 @@ class GoogleHomeDevice:
         """Returns next alarm"""
         timers = self.get_sorted_timers()
         return timers[0] if timers else None
+
+    def set_do_not_disturb_status(self, status: str) -> None:
+        """Stores Do Not Disturb status."""
+        self.do_not_disturb = bool(status)
+
+    def get_do_not_disturb_status(self) -> bool:
+        """Returns Do Not Disturb status."""
+        return self.do_not_disturb
 
 
 class GoogleHomeTimer:

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -37,7 +37,7 @@ class GoogleHomeDevice:
         self.ip_address = ip_address
         self.hardware = hardware
         self.available = True
-        self.do_not_disturb = False
+        self._do_not_disturb = False
         self._timers: List[GoogleHomeTimer] = []
         self._alarms: List[GoogleHomeAlarm] = []
 
@@ -86,12 +86,12 @@ class GoogleHomeDevice:
         return timers[0] if timers else None
 
     def set_do_not_disturb_status(self, status: str) -> None:
-        """Stores Do Not Disturb status."""
-        self.do_not_disturb = bool(status)
+        """Set Do Not Disturb status."""
+        self._do_not_disturb = bool(status)
 
     def get_do_not_disturb_status(self) -> bool:
-        """Returns Do Not Disturb status."""
-        return self.do_not_disturb
+        """Return Do Not Disturb status."""
+        return self._do_not_disturb
 
 
 class GoogleHomeTimer:

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -85,9 +85,9 @@ class GoogleHomeDevice:
         timers = self.get_sorted_timers()
         return timers[0] if timers else None
 
-    def set_do_not_disturb_status(self, status: str) -> None:
+    def set_do_not_disturb_status(self, status: bool) -> None:
         """Set Do Not Disturb status."""
-        self._do_not_disturb = bool(status)
+        self._do_not_disturb = status
 
     def get_do_not_disturb_status(self) -> bool:
         """Return Do Not Disturb status."""

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -85,11 +85,11 @@ class GoogleHomeDevice:
         timers = self.get_sorted_timers()
         return timers[0] if timers else None
 
-    def set_do_not_disturb_status(self, status: bool) -> None:
+    def set_do_not_disturb(self, status: bool) -> None:
         """Set Do Not Disturb status."""
         self._do_not_disturb = status
 
-    def get_do_not_disturb_status(self) -> bool:
+    def get_do_not_disturb(self) -> bool:
         """Return Do Not Disturb status."""
         return self._do_not_disturb
 

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platforms for Google Home"""
+"""Sensor platform for Google Home"""
 import logging
 from typing import Callable, Iterable, List, Optional
 

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -67,7 +67,7 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
 
         is_enabled = device.get_do_not_disturb_status()
 
-        return is_enabled
+        return not is_enabled
 
     async def async_turn_on(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Turn the entity on."""

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -65,24 +65,23 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
         if device is None:
             return False
 
-        is_enabled = device.get_do_not_disturb_status()
+        is_enabled = device.get_do_not_disturb()
 
         return not is_enabled
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # type: ignore[misc]
-        """Turn the entity on."""
+    async def set_do_not_disturb(self, enable: bool) -> None:
+        """Sets Do Not Disturb mode."""
         device = self.get_device()
         if device is None:
             _LOGGER.error("Device %s is not found.", self.device_name)
             return
 
-        await self.client.get_or_set_do_not_disturb(device=device, enable=True)
+        await self.client.get_or_set_do_not_disturb(device=device, enable=enable)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:  # type: ignore[misc]
+        """Turn the entity on."""
+        await self.set_do_not_disturb(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Turn the entity off."""
-        device = self.get_device()
-        if device is None:
-            _LOGGER.error("Device %s is not found.", self.device_name)
-            return
-
-        await self.client.get_or_set_do_not_disturb(device=device, enable=False)
+        await self.set_do_not_disturb(False)

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -27,10 +27,10 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
-    switch: List[SwitchEntity] = []
+    switches: List[SwitchEntity] = []
     for device in coordinator.data:
         if device.auth_token and device.available:
-            switch.append(
+            switches.append(
                 DoNotDisturbSwitch(
                     coordinator,
                     client,
@@ -38,8 +38,8 @@ async def async_setup_entry(
                 )
             )
 
-    if switch:
-        async_add_devices(switch)
+    if switches:
+        async_add_devices(switches)
 
     return True
 
@@ -59,7 +59,7 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if switch is on."""
+        """Return true if Do Not Disturb Mode is on."""
         device = self.get_device()
 
         if device is None:
@@ -67,7 +67,7 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
 
         is_enabled = device.get_do_not_disturb()
 
-        return not is_enabled
+        return is_enabled
 
     async def set_do_not_disturb(self, enable: bool) -> None:
         """Sets Do Not Disturb mode."""
@@ -76,7 +76,7 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
             _LOGGER.error("Device %s is not found.", self.device_name)
             return
 
-        await self.client.get_or_set_do_not_disturb(device=device, enable=enable)
+        await self.client.update_do_not_disturb(device=device, enable=enable)
 
     async def async_turn_on(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Turn the entity on."""

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -1,0 +1,88 @@
+"""Switch platform for Google Home"""
+import logging
+from typing import Any, Callable, Iterable, List
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DATA_CLIENT,
+    DATA_COORDINATOR,
+    DOMAIN,
+    ICON_DO_NOT_DISTURB,
+    LABEL_DO_NOT_DISTURB,
+)
+from .entity import GoogleHomeBaseEntity
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_devices: Callable[[Iterable[SwitchEntity]], None],
+) -> bool:
+    """Setup switch platform."""
+    client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
+    coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+
+    switch: List[SwitchEntity] = []
+    for device in coordinator.data:
+        if device.auth_token and device.available:
+            switch.append(
+                DoNotDisturbSwitch(
+                    coordinator,
+                    client,
+                    device.name,
+                )
+            )
+
+    if switch:
+        async_add_devices(switch)
+
+    return True
+
+
+class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
+    """Google Home Do Not Disturb switch."""
+
+    @property
+    def label(self) -> str:
+        """Label to use for name and unique id."""
+        return LABEL_DO_NOT_DISTURB
+
+    @property
+    def icon(self) -> str:
+        """Return the icon of the sensor."""
+        return ICON_DO_NOT_DISTURB
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        device = self.get_device()
+
+        if device is None:
+            return False
+
+        is_enabled = device.get_do_not_disturb_status()
+
+        return is_enabled
+
+    async def async_turn_on(self, **kwargs: Any) -> None:  # type: ignore[misc]
+        """Turn the entity on."""
+        device = self.get_device()
+        if device is None:
+            _LOGGER.error("Device %s is not found.", self.device_name)
+            return
+
+        await self.client.get_or_set_do_not_disturb(device=device, enable=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:  # type: ignore[misc]
+        """Turn the entity off."""
+        device = self.get_device()
+        if device is None:
+            _LOGGER.error("Device %s is not found.", self.device_name)
+            return
+
+        await self.client.get_or_set_do_not_disturb(device=device, enable=False)

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -1,5 +1,7 @@
 """Various types used in type hints."""
-from typing import List, Optional, Set, Tuple, TypedDict
+from typing import List, Mapping, Optional, Set, Tuple, TypedDict, Union
+
+JsonDict = Mapping[str, Union[bool, int, str, List[str]]]
 
 
 class AlarmJsonDict(TypedDict, total=False):


### PR DESCRIPTION
This adds a switch where you can toggle Do Not Disturb.

Alarms and timers will still ring but everything else is turned off. Where i live the feature does not seem to do much, but I believe it is very useful in other countries. 

I have tested it locally and it works! Can some one else test it also?

Because we have an update-interval set at 10 secs, the switch can jump back when used, it will switch to the correct positions when we retrieve new information. 😄 Maybe we should change this?