### PR TITLE
Trying to fix timeout error

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -206,6 +206,7 @@ class GlocaltokensApiClient:
                 "%s device timed out while trying to get alarms and timers.",
                 device.name,
             )
+            device.available = False
 
         return device
 

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -1,5 +1,5 @@
 """Sample API Client."""
-import asyncio
+from asyncio import gather
 import json
 import logging
 from typing import Dict, List, Optional
@@ -182,7 +182,6 @@ class GlocaltokensApiClient:
                         response,
                     )
                     device.available = False
-
         except ClientConnectorError:
             _LOGGER.debug(
                 (
@@ -229,14 +228,13 @@ class GlocaltokensApiClient:
                     device.name,
                 )
 
-        coordinator_data = await asyncio.gather(
+        coordinator_data = await gather(
             *[
                 self.get_alarms_and_timers(device, device.ip_address, device.auth_token)
                 for device in devices
                 if device.ip_address and device.auth_token
             ]
         )
-
         return coordinator_data
 
     async def delete_alarm_or_timer(

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -64,7 +64,7 @@ HEADERS = {
     HEADER_CAST_LOCAL_AUTH: "",
     HEADER_CONTENT_TYPE: "application/json",
 }
-TIMEOUT = 10  # Request Timeout in seconds
+TIMEOUT = 5  # Request Timeout in seconds
 
 # TIMESTRINGS
 TIME_STR_FORMAT = "%H:%M:%S"

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -64,7 +64,7 @@ HEADERS = {
     HEADER_CAST_LOCAL_AUTH: "",
     HEADER_CONTENT_TYPE: "application/json",
 }
-TIMEOUT = 5  # Request Timeout in seconds
+TIMEOUT = 2  # Request Timeout in seconds
 
 # TIMESTRINGS
 TIME_STR_FORMAT = "%H:%M:%S"


### PR DESCRIPTION
@KapJI @leikoilja 

We get the error because aiohttp, for some reason, throws an exception if we get a status above 400. 

If we set raise_for_error (for the aiohttp client) to False it still throws an exception if over 400. 

Maybe we found a bug in aiohttp? or something else is happening. 

If we catch broad we can mitigate the error for now. But it would be better to actually find out why this is happening.

What do you guys think?

We should properly also adjust timeout for local request to be 1 sec or so? 

Fixes #149