### PR TITLE
Stricter Labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,10 @@
 dependencies:
-  - poetry.lock
+  - all: ["poetry.lock", "!*.py"]
 
 documentation:
-  - "*.md"
+  - any: ["*.md"]
+    all: ["!*.py"]
 
 github structure:
-  - .github/*
+  - any: [".github/*"]
+    all: ["!*.py"]


### PR DESCRIPTION
Right now Labeler is more annoying than useful. Reduce number of false positives by adding labels only to PRs where no python code is changed.