### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -49,7 +49,5 @@ logger:
 <!-- Paste logs below here-->
 
 ```text
-
 Add your logs here.
-
 ```

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -35,15 +35,8 @@ Add version here.
 
 ## Logs
 
-```text
-Add your logs here.
-```
-
-## Debug log
-
 <!-- To enable debug logs, put the below snippet in your configuration.yaml file.
 You can delete the below snippet before you submit this issue.
--->
 
 ```yaml
 logger:
@@ -51,11 +44,12 @@ logger:
   logs:
     custom_components.google_home: debug
 ```
+-->
 
 <!-- Paste logs below here-->
 
 ```text
 
-Add your debug logs here.
+Add your logs here.
 
 ```

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -38,12 +38,10 @@ Add version here.
 <!-- To enable debug logs, put the below snippet in your configuration.yaml file.
 You can delete the below snippet before you submit this issue.
 
-```yaml
 logger:
   default: debug
   logs:
     custom_components.google_home: debug
-```
 -->
 
 <!-- Paste logs below here-->

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -33,16 +33,6 @@ If you are unsure about the version check the [github release here](https://gith
 Add version here.
 ```
 
-## Glocaltokens Version (Underlying package)
-
-<!-- Currently installed version of the underlying package that Google Home integration relies on.
-Please run `pip show glocaltokens` in the command line and paste the information below.
--->
-
-```text
-Add pip information here.
-```
-
 ## Logs
 
 ```text

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -36,7 +36,6 @@ Add version here.
 ## Logs
 
 <!-- To enable debug logs, put the below snippet in your configuration.yaml file.
-You can delete the below snippet before you submit this issue.
 
 logger:
   default: debug


### PR DESCRIPTION
`glocaltokens` version is linked to integration version, let's not ask people to figure out that.

Also remove duplicated Logs section and hide instructions to the comment.