### PR TITLE
Adding alarm state 4 

### DIFF
--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -169,7 +169,7 @@ class GoogleHomeAlarmStatus(Enum):
     SNOOZED = 3
     # We need to find out what this state means
     # See: https://github.com/leikoilja/ha-google-home/issues/176
-    UNKNOWN = 4
+    STATE_FOUR = 4
 
 
 class GoogleHomeTimerStatus(Enum):

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -167,6 +167,9 @@ class GoogleHomeAlarmStatus(Enum):
     SET = 1
     RINGING = 2
     SNOOZED = 3
+    # We need to find out what this state means
+    # See: https://github.com/leikoilja/ha-google-home/issues/176
+    UNKNOWN = 4
 
 
 class GoogleHomeTimerStatus(Enum):


### PR DESCRIPTION
A quick fix to add state 4 to the alarm state Enum.
Note, i don't think we should call it `unknown` or anything like that because the user might be even more confused by `unknown` state thinking it's a bug.

Closing #176 
