### PR TITLE
Fix parsing for paused timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Each of the alarms has the following keys:
 
 | Key              | Value type                   | Description                                                                                                                                                                                             |
 | ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | Google Home corresponding ID | Used to identify the alarm                                                                                                                                                                              |
-| `label`          | Name                         | Name of the alarm, this can be set when making the alarm                                                                                                                                                |
+| `alarm_id`       | Google Home corresponding ID | Used to identify the alarm                                                                                                                                                                              |
 | `fire_time`      | Seconds                      | Raw value coming from Google Home device until the alarm goes off                                                                                                                                       |
 | `local_time`     | Time                         | Time when the alarm goes off, in respect to the Home Assistant's timezone                                                                                                                               |
 | `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                                                                                                                                                  |
+| `status`         | Status (string)              | The current status of the alarm, either `none`, `set`, `ringing`, `snoozed` or `inactive`                                                                                                               |
+| `label`          | Name                         | Name of the alarm, this can be set when making the alarm                                                                                                                                                |
 | `recurrence`     | List of integers             | Days of the week when the alarm will go off. Please note, respecting Google set standard, the week starts from Sunday, therefore is denoted by 0. Correspondingly, Monday is 1, Saturday is 6 and so on |
-| `status`         | Status (string)              | The current status of the alarm, either `none`, `set`, `ringing` or `snoozed`                                                                                                                           |
 
 The state value shows the next alarm as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one alarm set, otherwise it is set to `unavailable`.
 This matches state format of [standard next alarm sensor](https://companion.home-assistant.io/docs/core/sensors/#next-alarm-sensor) provided by `mobile_app`.
@@ -82,15 +82,15 @@ You can have multiple timers on your Google Home device. Home Assistant
 timers sensor will represent all of them in the state attributes as a list `timers`.
 Each of the timers has the following keys:
 
-| Key              | Value type                   | Description                                                               |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `id`             | Google Home corresponding ID | Used to identify the timer                                                |
-| `label`          | Name                         | Name of the timer, this can be set when making the timer                  |
-| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off         |
-| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone |
-| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                    |
-| `duration`       | Seconds                      | Timer duration in seconds                                                 |
-| `status`         | Status (string)              | The current status of the timer, either `none`, `set`, or `ringing`       |
+| Key              | Value type                   | Description                                                                  |
+| ---------------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| `timer_id`       | Google Home corresponding ID | Used to identify the timer                                                   |
+| `fire_time`      | Seconds                      | Raw value coming from Google Home device until the timer goes off            |
+| `local_time`     | Time                         | Time when the timer goes off, in respect to the Home Assistant's timezone    |
+| `local_time_iso` | Time in ISO 8601 standard    | Useful for automations                                                       |
+| `duration`       | Seconds                      | Timer duration in seconds                                                    |
+| `status`         | Status (string)              | The current status of the timer, either `none`, `set`, `ringing` or `paused` |
+| `label`          | Name                         | Name of the timer, this can be set when making the timer                     |
 
 The state value shows the next timer as a timestring (i.e.: `2021-03-07T15:26:17+01:00`) if there is at least one timer set, otherwise it is set to `unavailable`.
 

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from enum import Enum
+import sys
 from typing import List, Optional
 
 from homeassistant.util.dt import as_local, utc_from_timestamp
@@ -59,7 +60,7 @@ class GoogleHomeDevice:
         self._timers = [
             GoogleHomeTimer(
                 timer_id=timer["id"],
-                fire_time=timer["fire_time"],
+                fire_time=timer["fire_time"] if "fire_time" in timer else None,
                 duration=timer["original_duration"],
                 status=timer["status"],
                 label=timer.get("label"),
@@ -77,8 +78,11 @@ class GoogleHomeDevice:
         return alarms[0] if alarms else None
 
     def get_sorted_timers(self) -> List[GoogleHomeTimer]:
-        """Returns timers in a sorted order"""
-        return sorted(self._timers, key=lambda k: k.fire_time)
+        """Returns timers in a sorted order. If timer is paused, put it in the end."""
+        return sorted(
+            self._timers,
+            key=lambda k: k.fire_time if k.fire_time is not None else sys.maxsize,
+        )
 
     def get_next_timer(self) -> Optional[GoogleHomeTimer]:
         """Returns next alarm"""
@@ -100,27 +104,34 @@ class GoogleHomeTimer:
     def __init__(
         self,
         timer_id: str,
-        fire_time: int,
+        fire_time: Optional[int],
         duration: int,
         status: int,
         label: Optional[str],
     ) -> None:
         self.timer_id = timer_id
         self.duration = str(timedelta(seconds=convert_from_ms_to_s(duration)))
-        self.fire_time = convert_from_ms_to_s(fire_time)
         self.status = GoogleHomeTimerStatus(status)
         self.label = label
 
-        dt_utc = utc_from_timestamp(self.fire_time)
-        dt_local = as_local(dt_utc)
-        self.local_time = dt_local.strftime(DATETIME_STR_FORMAT)
-        self.local_time_iso = dt_local.isoformat()
+        if fire_time is None:
+            self.fire_time = None
+            self.local_time = None
+            self.local_time_iso = None
+        else:
+            self.fire_time = convert_from_ms_to_s(fire_time)
+            dt_utc = utc_from_timestamp(self.fire_time)
+            dt_local = as_local(dt_utc)
+            self.local_time = dt_local.strftime(DATETIME_STR_FORMAT)
+            self.local_time_iso = dt_local.isoformat()
 
     def as_dict(self) -> GoogleHomeTimerDict:
         """Return typed dict representation."""
         return {
             "timer_id": self.timer_id,
             "fire_time": self.fire_time,
+            "local_time": self.local_time,
+            "local_time_iso": self.local_time_iso,
             "duration": self.duration,
             "status": self.status.name.lower(),
             "label": self.label,
@@ -154,6 +165,8 @@ class GoogleHomeAlarm:
         return {
             "alarm_id": self.alarm_id,
             "fire_time": self.fire_time,
+            "local_time": self.local_time,
+            "local_time_iso": self.local_time_iso,
             "status": self.status.name.lower(),
             "label": self.label,
             "recurrence": self.recurrence,

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -60,7 +60,7 @@ class GoogleHomeDevice:
         self._timers = [
             GoogleHomeTimer(
                 timer_id=timer["id"],
-                fire_time=timer["fire_time"] if "fire_time" in timer else None,
+                fire_time=timer.get("fire_time"),
                 duration=timer["original_duration"],
                 status=timer["status"],
                 label=timer.get("label"),

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -252,7 +252,11 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
         if not device:
             return None
         timer = device.get_next_timer()
-        return timer.local_time_iso if timer else STATE_UNAVAILABLE
+        return (
+            timer.local_time_iso
+            if timer and timer.local_time_iso
+            else STATE_UNAVAILABLE
+        )
 
     @property
     def device_state_attributes(self) -> TimersAttributes:

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -29,6 +29,8 @@ class GoogleHomeAlarmDict(TypedDict):
 
     alarm_id: str
     fire_time: int
+    local_time: str
+    local_time_iso: str
     status: str
     label: Optional[str]
     recurrence: Optional[str]
@@ -38,7 +40,9 @@ class GoogleHomeTimerDict(TypedDict):
     """Typed dict representation of Google Home timer"""
 
     timer_id: str
-    fire_time: int
+    fire_time: Optional[int]
+    local_time: Optional[str]
+    local_time_iso: Optional[str]
     duration: str
     status: str
     label: Optional[str]


### PR DESCRIPTION
- Fixes #187, tested on Nest Hub Mini
- Also add `local_time` and `local_time_iso` to the sensor attributes as we describe in README
- Update README to match the names and order in HA
