### PR TITLE
Put inactive alarms to the end of sorted list

### DIFF
--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -69,8 +69,13 @@ class GoogleHomeDevice:
         ]
 
     def get_sorted_alarms(self) -> List[GoogleHomeAlarm]:
-        """Returns alarms in a sorted order"""
-        return sorted(self._alarms, key=lambda k: k.fire_time)
+        """Returns alarms in a sorted order. Inactive alarms are in the end."""
+        return sorted(
+            self._alarms,
+            key=lambda k: k.fire_time
+            if k.status != GoogleHomeAlarmStatus.INACTIVE
+            else k.fire_time + sys.maxsize,
+        )
 
     def get_next_alarm(self) -> Optional[GoogleHomeAlarm]:
         """Returns next alarm"""

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -175,7 +175,11 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
         if not device:
             return None
         next_alarm = device.get_next_alarm()
-        return next_alarm.local_time_iso if next_alarm else STATE_UNAVAILABLE
+        return (
+            next_alarm.local_time_iso
+            if next_alarm and next_alarm.status != GoogleHomeAlarmStatus.INACTIVE
+            else STATE_UNAVAILABLE
+        )
 
     @property
     def device_state_attributes(self) -> AlarmsAttributes:


### PR DESCRIPTION
- Add them to the end but still sorted.
- If next alarm is inactive, set state to `unavailable`.

Fixes #204 