### PR TITLE
Re-add Dependabot labels setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    labels:
+      - "dependencies"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This actually prevents from adding dependency type label.