### PR TITLE
Add exclusions for Chromecast devices

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -17,6 +17,7 @@ from .const import (
     API_ENDPOINT_DELETE,
     API_ENDPOINT_DO_NOT_DISTURB,
     API_ENDPOINT_REBOOT,
+    HARDWARE_CHROMECAST,
     HEADER_CAST_LOCAL_AUTH,
     HEADER_CONTENT_TYPE,
     JSON_ALARM,
@@ -24,7 +25,6 @@ from .const import (
     JSON_TIMER,
     PORT,
     TIMEOUT,
-    HARDWARE_CHROMECAST,
 )
 from .exceptions import InvalidMasterToken
 from .models import GoogleHomeDevice
@@ -131,8 +131,8 @@ class GlocaltokensApiClient:
                     ),
                     device.name,
                 )
-            if device.hardware in HARDWARE_CHROMECAST :
-                device.available = False 
+            if device.hardware in HARDWARE_CHROMECAST:
+                device.available = False
                 _LOGGER.debug(
                     (
                         "The device %s (hardware='%s') is not Google Home "

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -24,6 +24,7 @@ from .const import (
     JSON_TIMER,
     PORT,
     TIMEOUT,
+    HARDWARE_CHROMECAST,
 )
 from .exceptions import InvalidMasterToken
 from .models import GoogleHomeDevice
@@ -130,6 +131,16 @@ class GlocaltokensApiClient:
                     ),
                     device.name,
                 )
+            if device.hardware in HARDWARE_CHROMECAST :
+                device.available = False 
+                _LOGGER.debug(
+                    (
+                        "The device %s (hardware='%s') is not Google Home "
+                        "compatible and is currently unsupported. "
+                    ),
+                    device.name,
+                    device.hardware,
+                )
 
         coordinator_data = await asyncio.gather(
             *[
@@ -137,7 +148,7 @@ class GlocaltokensApiClient:
                     device=device,
                 )
                 for device in devices
-                if device.ip_address and device.auth_token
+                if device.ip_address and device.auth_token and device.available
             ]
         )
         return coordinator_data

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -24,6 +24,9 @@ ICON_ALARMS: Final[str] = "mdi:alarm-multiple"
 ICON_TIMERS: Final[str] = "mdi:timer-sand"
 ICON_DO_NOT_DISTURB: Final[str] = "mdi:minus-circle"
 
+# Hardware
+HARDWARE_CHROMECAST: Final[List[str]] = ["Chromecast","Chromecast Ultra"]
+
 # Device classes
 BINARY_SENSOR_DEVICE_CLASS: Final[str] = "connectivity"
 

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -25,7 +25,7 @@ ICON_TIMERS: Final[str] = "mdi:timer-sand"
 ICON_DO_NOT_DISTURB: Final[str] = "mdi:minus-circle"
 
 # Hardware
-HARDWARE_CHROMECAST: Final[List[str]] = ["Chromecast","Chromecast Ultra"]
+HARDWARE_CHROMECAST: Final[List[str]] = ["Chromecast", "Chromecast Ultra"]
 
 # Device classes
 BINARY_SENSOR_DEVICE_CLASS: Final[str] = "connectivity"


### PR DESCRIPTION
Since chromecast devices do not currently support the google home api, exclude these devices from api calls in the same manner as devices missing IP's or auth tokens.

PR to address issue #211 