### PR TITLE
Fix Labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,6 @@
 dependencies:
-  - all: ["poetry.lock", "!**/*.py"]
+  - any: ["poetry.lock"]
+    all: ["!**/*.py"]
 
 documentation:
   - any: ["**/*.md"]


### PR DESCRIPTION
It removed `dependencies` label on https://github.com/leikoilja/ha-google-home/pull/215 because `pyproject.toml` doesn't match `poetry.lock` glob.

I need to read their docs more carefully.