### PR TITLE
Modernise type hints

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -33,3 +33,7 @@ jobs:
       - name: Run pre-commit on all files
         run: |
           poetry run pre-commit run --all-files --show-diff-on-failure --color=always
+
+      - name: Run python-typing-update
+        run: |
+          poetry run pre-commit run --hook-stage manual python-typing-update --all-files --show-diff-on-failure --color=always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,16 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
+  - repo: https://github.com/cdce8p/python-typing-update
+    rev: v0.3.3
+    hooks:
+      # Run `python-typing-update` hook manually from time to time
+      # to update python typing syntax.
+      # Will require manual work, before submitting changes!
+      - id: python-typing-update
+        stages: [manual]
+        args:
+          - --py38-plus
+          - --force
+          - --keep-updates
+        files: ^.+\.py$

--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -1,7 +1,9 @@
 """Sample API Client."""
+from __future__ import annotations
+
 import asyncio
 import logging
-from typing import Dict, List, Literal, Optional, cast
+from typing import List, Literal, cast
 
 from aiohttp import ClientError, ClientSession
 from aiohttp.client_exceptions import ClientConnectorError, ContentTypeError
@@ -39,11 +41,11 @@ class GlocaltokensApiClient:
         self,
         hass: HomeAssistant,
         session: ClientSession,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-        master_token: Optional[str] = None,
-        android_id: Optional[str] = None,
-        zeroconf_instance: Optional[Zeroconf] = None,
+        username: str | None = None,
+        password: str | None = None,
+        master_token: str | None = None,
+        android_id: str | None = None,
+        zeroconf_instance: Zeroconf | None = None,
     ):
         """Sample API Client."""
         self.hass = hass
@@ -59,13 +61,13 @@ class GlocaltokensApiClient:
             android_id=android_id,
             verbose=verbose,
         )
-        self.google_devices: List[GoogleHomeDevice] = []
+        self.google_devices: list[GoogleHomeDevice] = []
         self.zeroconf_instance = zeroconf_instance
 
     async def async_get_master_token(self) -> str:
         """Get master API token"""
 
-        def _get_master_token() -> Optional[str]:
+        def _get_master_token() -> str | None:
             return self._client.get_master_token()
 
         master_token = await self.hass.async_add_executor_job(_get_master_token)
@@ -73,13 +75,13 @@ class GlocaltokensApiClient:
             raise InvalidMasterToken
         return master_token
 
-    async def get_google_devices(self) -> List[GoogleHomeDevice]:
+    async def get_google_devices(self) -> list[GoogleHomeDevice]:
         """Get google device authentication tokens.
         Note this method will fetch necessary access tokens if missing"""
 
         if not self.google_devices:
 
-            def _get_google_devices() -> List[Device]:
+            def _get_google_devices() -> list[Device]:
                 return self._client.get_google_devices(
                     zeroconf_instance=self.zeroconf_instance,
                     force_homegraph_reload=True,
@@ -97,10 +99,10 @@ class GlocaltokensApiClient:
             ]
         return self.google_devices
 
-    async def get_android_id(self) -> Optional[str]:
+    async def get_android_id(self) -> str | None:
         """Generate random android_id"""
 
-        def _get_android_id() -> Optional[str]:
+        def _get_android_id() -> str | None:
             return self._client.get_android_id()
 
         return await self.hass.async_add_executor_job(_get_android_id)
@@ -111,7 +113,7 @@ class GlocaltokensApiClient:
         Note: port argument is unused because all request must be done to 8443"""
         return f"https://{ip_address}:{port}/{api_endpoint}"
 
-    async def update_google_devices_information(self) -> List[GoogleHomeDevice]:
+    async def update_google_devices_information(self) -> list[GoogleHomeDevice]:
         """Retrieves devices from glocaltokens and
         fetches alarm/timer data from each of the device"""
 
@@ -246,7 +248,7 @@ class GlocaltokensApiClient:
             )
 
     async def update_do_not_disturb(
-        self, device: GoogleHomeDevice, enable: Optional[bool] = None
+        self, device: GoogleHomeDevice, enable: bool | None = None
     ) -> GoogleHomeDevice:
         """Gets or sets the do not disturb setting on a Google Home device."""
 
@@ -300,9 +302,9 @@ class GlocaltokensApiClient:
         method: Literal["GET", "POST"],
         endpoint: str,
         device: GoogleHomeDevice,
-        data: Optional[JsonDict] = None,
+        data: JsonDict | None = None,
         polling: bool = False,
-    ) -> Optional[JsonDict]:
+    ) -> JsonDict | None:
         """Shared request method"""
 
         if device.ip_address is None:
@@ -315,7 +317,7 @@ class GlocaltokensApiClient:
 
         url = self.create_url(device.ip_address, PORT, endpoint)
 
-        headers: Dict[str, str] = {
+        headers: dict[str, str] = {
             HEADER_CAST_LOCAL_AUTH: device.auth_token,
             HEADER_CONTENT_TYPE: "application/json",
         }

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from requests.exceptions import RequestException
 import voluptuous as vol
@@ -35,11 +35,11 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self._errors: Dict[str, str] = {}
+        self._errors: dict[str, str] = {}
 
     async def async_step_user(
-        self, user_input: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Handle a flow initialized by the user."""
         self._errors = {}
 
@@ -72,8 +72,8 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return GoogleHomeOptionsFlowHandler(config_entry)
 
     async def _show_config_form(
-        self, _user_input: Optional[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, _user_input: dict[str, Any] | None
+    ) -> dict[str, Any]:
         """Show the configuration form to edit location data."""
         return self.async_show_form(
             step_id="user",
@@ -86,7 +86,7 @@ class GoogleHomeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def _test_credentials(self, client: GlocaltokensApiClient) -> Optional[str]:
+    async def _test_credentials(self, client: GlocaltokensApiClient) -> str | None:
         """Returns true and master token if credentials are valid."""
         try:
             master_token = await client.async_get_master_token()
@@ -106,8 +106,8 @@ class GoogleHomeOptionsFlowHandler(config_entries.OptionsFlow):
         self.options = dict(config_entry.options)
 
     async def async_step_init(
-        self, user_input: Optional[OptionsFlowDict] = None
-    ) -> Dict[str, Any]:
+        self, user_input: OptionsFlowDict | None = None
+    ) -> dict[str, Any]:
         """Manage the options."""
         if user_input is not None:
             self.options.update(user_input)

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -1,5 +1,7 @@
 """Constants for Google Home."""
-from typing import Final, List
+from __future__ import annotations
+
+from typing import Final
 
 from homeassistant.util.dt import DATE_STR_FORMAT
 
@@ -30,7 +32,7 @@ BINARY_SENSOR_DEVICE_CLASS: Final[str] = "connectivity"
 # Platforms
 SENSOR: Final[str] = "sensor"
 SWITCH: Final[str] = "switch"
-PLATFORMS: Final[List[str]] = [SENSOR, SWITCH]
+PLATFORMS: Final[list[str]] = [SENSOR, SWITCH]
 
 # Services
 SERVICE_REBOOT: Final[str] = "reboot_device"

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -1,7 +1,7 @@
 """Defines base entities for Google Home"""
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -51,10 +51,10 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
             "manufacturer": MANUFACTURER,
         }
 
-    def get_device(self) -> Optional[GoogleHomeDevice]:
+    def get_device(self) -> GoogleHomeDevice | None:
         """Return the device matched by device name
         from the list of google devices in coordinator_data"""
-        matched_devices: List[GoogleHomeDevice] = [
+        matched_devices: list[GoogleHomeDevice] = [
             device
             for device in self.coordinator.data
             if device.name == self.device_name

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -1,11 +1,9 @@
 """Models for Google Home"""
-
 from __future__ import annotations
 
 from datetime import timedelta
 from enum import Enum
 import sys
-from typing import List, Optional
 
 from homeassistant.util.dt import as_local, utc_from_timestamp
 
@@ -29,9 +27,9 @@ class GoogleHomeDevice:
     def __init__(
         self,
         name: str,
-        auth_token: Optional[str],
-        ip_address: Optional[str] = None,
-        hardware: Optional[str] = None,
+        auth_token: str | None,
+        ip_address: str | None = None,
+        hardware: str | None = None,
     ):
         self.name = name
         self.auth_token = auth_token
@@ -39,10 +37,10 @@ class GoogleHomeDevice:
         self.hardware = hardware
         self.available = True
         self._do_not_disturb = False
-        self._timers: List[GoogleHomeTimer] = []
-        self._alarms: List[GoogleHomeAlarm] = []
+        self._timers: list[GoogleHomeTimer] = []
+        self._alarms: list[GoogleHomeAlarm] = []
 
-    def set_alarms(self, alarms: List[AlarmJsonDict]) -> None:
+    def set_alarms(self, alarms: list[AlarmJsonDict]) -> None:
         """Stores alarms as GoogleHomeAlarm objects"""
         self._alarms = [
             GoogleHomeAlarm(
@@ -55,7 +53,7 @@ class GoogleHomeDevice:
             for alarm in alarms
         ]
 
-    def set_timers(self, timers: List[TimerJsonDict]) -> None:
+    def set_timers(self, timers: list[TimerJsonDict]) -> None:
         """Stores timers as GoogleHomeTimer objects"""
         self._timers = [
             GoogleHomeTimer(
@@ -68,7 +66,7 @@ class GoogleHomeDevice:
             for timer in timers
         ]
 
-    def get_sorted_alarms(self) -> List[GoogleHomeAlarm]:
+    def get_sorted_alarms(self) -> list[GoogleHomeAlarm]:
         """Returns alarms in a sorted order. Inactive alarms are in the end."""
         return sorted(
             self._alarms,
@@ -77,19 +75,19 @@ class GoogleHomeDevice:
             else k.fire_time + sys.maxsize,
         )
 
-    def get_next_alarm(self) -> Optional[GoogleHomeAlarm]:
+    def get_next_alarm(self) -> GoogleHomeAlarm | None:
         """Returns next alarm"""
         alarms = self.get_sorted_alarms()
         return alarms[0] if alarms else None
 
-    def get_sorted_timers(self) -> List[GoogleHomeTimer]:
+    def get_sorted_timers(self) -> list[GoogleHomeTimer]:
         """Returns timers in a sorted order. If timer is paused, put it in the end."""
         return sorted(
             self._timers,
             key=lambda k: k.fire_time if k.fire_time is not None else sys.maxsize,
         )
 
-    def get_next_timer(self) -> Optional[GoogleHomeTimer]:
+    def get_next_timer(self) -> GoogleHomeTimer | None:
         """Returns next alarm"""
         timers = self.get_sorted_timers()
         return timers[0] if timers else None
@@ -109,10 +107,10 @@ class GoogleHomeTimer:
     def __init__(
         self,
         timer_id: str,
-        fire_time: Optional[int],
+        fire_time: int | None,
         duration: int,
         status: int,
-        label: Optional[str],
+        label: str | None,
     ) -> None:
         self.timer_id = timer_id
         self.duration = str(timedelta(seconds=convert_from_ms_to_s(duration)))
@@ -151,8 +149,8 @@ class GoogleHomeAlarm:
         alarm_id: str,
         fire_time: int,
         status: int,
-        label: Optional[str],
-        recurrence: Optional[str],
+        label: str | None,
+        recurrence: str | None,
     ) -> None:
         self.alarm_id = alarm_id
         self.recurrence = recurrence

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -1,6 +1,8 @@
 """Sensor platform for Google Home"""
+from __future__ import annotations
+
 import logging
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable
 
 import voluptuous as vol
 
@@ -48,7 +50,7 @@ async def async_setup_entry(
     """Setup sensor platform."""
     client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
-    sensors: List[Entity] = []
+    sensors: list[Entity] = []
     for device in coordinator.data:
         sensors.append(
             GoogleHomeDeviceSensor(
@@ -110,7 +112,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
         return ICON_TOKEN
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> str | None:
         device = self.get_device()
         return device.auth_token if device else None
 
@@ -170,7 +172,7 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
         return DEVICE_CLASS_TIMESTAMP
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> str | None:
         device = self.get_device()
         if not device:
             return None
@@ -200,7 +202,7 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             else GoogleHomeAlarmStatus.NONE.name.lower()
         )
 
-    def _get_alarms_data(self) -> List[GoogleHomeAlarmDict]:
+    def _get_alarms_data(self) -> list[GoogleHomeAlarmDict]:
         """Update alarms data extracting it from coordinator"""
         device = self.get_device()
         return (
@@ -251,7 +253,7 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
         return DEVICE_CLASS_TIMESTAMP
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> str | None:
         device = self.get_device()
         if not device:
             return None
@@ -281,7 +283,7 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
             else GoogleHomeTimerStatus.NONE.name.lower()
         )
 
-    def _get_timers_data(self) -> List[GoogleHomeTimerDict]:
+    def _get_timers_data(self) -> list[GoogleHomeTimerDict]:
         """Update timers data extracting it from coordinator"""
         device = self.get_device()
         return (

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -1,6 +1,8 @@
 """Switch platform for Google Home"""
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Iterable, List
+from typing import Any, Callable, Iterable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -27,7 +29,7 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][entry.entry_id][DATA_CLIENT]
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
-    switches: List[SwitchEntity] = []
+    switches: list[SwitchEntity] = []
     for device in coordinator.data:
         if device.auth_token and device.available:
             switches.append(

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -1,5 +1,7 @@
 """Various types used in type hints."""
-from typing import List, Mapping, Optional, Set, Tuple, TypedDict, Union
+from __future__ import annotations
+
+from typing import List, Mapping, TypedDict, Union
 
 
 class AlarmJsonDict(TypedDict, total=False):
@@ -8,8 +10,8 @@ class AlarmJsonDict(TypedDict, total=False):
     id: str
     fire_time: int
     status: int
-    label: Optional[str]
-    recurrence: Optional[str]
+    label: str | None
+    recurrence: str | None
 
 
 class TimerJsonDict(TypedDict, total=False):
@@ -19,7 +21,7 @@ class TimerJsonDict(TypedDict, total=False):
     fire_time: int
     original_duration: int
     status: int
-    label: Optional[str]
+    label: str | None
 
 
 class GoogleHomeAlarmDict(TypedDict):
@@ -30,29 +32,29 @@ class GoogleHomeAlarmDict(TypedDict):
     local_time: str
     local_time_iso: str
     status: str
-    label: Optional[str]
-    recurrence: Optional[str]
+    label: str | None
+    recurrence: str | None
 
 
 class GoogleHomeTimerDict(TypedDict):
     """Typed dict representation of Google Home timer"""
 
     timer_id: str
-    fire_time: Optional[int]
-    local_time: Optional[str]
-    local_time_iso: Optional[str]
+    fire_time: int | None
+    local_time: str | None
+    local_time_iso: str | None
     duration: str
     status: str
-    label: Optional[str]
+    label: str | None
 
 
 class DeviceAttributes(TypedDict):
     """Typed dict for device attributes"""
 
     device_name: str
-    auth_token: Optional[str]
-    ip_address: Optional[str]
-    hardware: Optional[str]
+    auth_token: str | None
+    ip_address: str | None
+    hardware: str | None
     available: bool
     integration: str
 
@@ -61,7 +63,7 @@ class AlarmsAttributes(TypedDict):
     """Typed dict for alarms attributes"""
 
     next_alarm_status: str
-    alarms: List[GoogleHomeAlarmDict]
+    alarms: list[GoogleHomeAlarmDict]
     integration: str
 
 
@@ -69,14 +71,14 @@ class TimersAttributes(TypedDict):
     """Typed dict for timers attributes"""
 
     next_timer_status: str
-    timers: List[GoogleHomeTimerDict]
+    timers: list[GoogleHomeTimerDict]
     integration: str
 
 
 class DeviceInfo(TypedDict):
     """Typed dict for device_info"""
 
-    identifiers: Set[Tuple[str, str]]
+    identifiers: set[tuple[str, str]]
     name: str
     manufacturer: str
 


### PR DESCRIPTION
[python-typing-update](https://github.com/cdce8p/python-typing-update) is created by HA maintainers to update type hints to the new [PEP 585](https://www.python.org/dev/peps/pep-0585/) style.

Old ones will be deprecated in Python 3.9 and eventually removed few year later. Before that they can be used with:
```python
from __future__ import annotations
```

The advantage is that they don't need to be imported and python authors don't need to maintain parallel type definitions in `typing` module. Basically this is the future of python.

This tool can be run with:
```shell
poetry run pre-commit run --hook-stage manual python-typing-update --all-files
```

It can only run on committed files, because of that we can't add it to default `pre-commit` workflow. Otherwise you want be able to commit files if it modified something. But can add it to linting job.