### PR TITLE
Ignoring json in codespells

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,5 +32,5 @@ ignore_missing_imports = True
 
 [codespell]
 quiet-level = 2
-skip = poetry.lock,./.git,./.mypy_cache
+skip = poetry.lock,./.git,./.mypy_cache,*.json
 ignore-words-list = hass


### PR DESCRIPTION
We shouldn't really speck json files for codespells