### PR TITLE
Add config option for changing update interval.

### DIFF
--- a/custom_components/google_home/__init__.py
+++ b/custom_components/google_home/__init__.py
@@ -20,6 +20,7 @@ from .api import GlocaltokensApiClient
 from .const import (
     CONF_ANDROID_ID,
     CONF_MASTER_TOKEN,
+    CONF_UPDATE_INTERVAL,
     DATA_CLIENT,
     DATA_COORDINATOR,
     DOMAIN,
@@ -42,6 +43,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     password = entry.data.get(CONF_PASSWORD)
     android_id = entry.data.get(CONF_ANDROID_ID)
     master_token = entry.data.get(CONF_MASTER_TOKEN)
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+
+    _LOGGER.debug(
+        "Coordinator update_interval is: %s", timedelta(seconds=update_interval)
+    )
 
     session = async_get_clientsession(hass, verify_ssl=False)
 
@@ -61,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=SENSOR,
         update_method=glocaltokens_client.update_google_devices_information,
-        update_interval=timedelta(seconds=UPDATE_INTERVAL),
+        update_interval=timedelta(seconds=update_interval),
     )
 
     await coordinator.async_refresh()

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -14,6 +14,7 @@ MANUFACTURER: Final[str] = "google_home"
 ATTRIBUTION: Final[str] = "json"
 ISSUE_URL: Final[str] = "https://github.com/leikoilja/ha-google-home/issues"
 CONF_DATA_COLLECTION: Final[str] = "data_collection"
+CONF_UPDATE_INTERVAL: Final[str] = "update_interval"
 
 DATA_CLIENT: Final[str] = "client"
 DATA_COORDINATOR: Final[str] = "coordinator"
@@ -84,7 +85,7 @@ DATETIME_STR_FORMAT: Final[str] = f"{DATE_STR_FORMAT} {TIME_STR_FORMAT}"
 
 # Access token only lives about 1 hour
 # Update often to fetch timers in timely manner
-UPDATE_INTERVAL: Final[int] = 10  # sec
+UPDATE_INTERVAL: Final[int] = 180  # sec
 
 # JSON parameter values when retrieving information from devices
 JSON_ALARM: Final[str] = "alarm"

--- a/custom_components/google_home/translations/en.json
+++ b/custom_components/google_home/translations/en.json
@@ -21,7 +21,8 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Allow anonymous diagnostic data collection (See https://github.com/leikoilja/ha-google-home#diagnostic-data-collection)."
+          "data_collection": "Allow anonymous diagnostic data collection (See https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
+          "update_interval": "Change update interval. Increase this if you are suffering from devices timing out. Default: 180 (Seconds)"
         }
       }
     }


### PR DESCRIPTION
As discussed in #202 and [comment](https://github.com/leikoilja/ha-google-home/issues/202#issuecomment-895221500)

Adds ability for the user to change the update interval. This will make it possible for users who suffer for timeout problems to change their update interval as it seems this can help with it.

Also this now sets the default update interval to 180 seconds instead of 10 as pointed out in comment. Users should at their own risk tune it what they need.

This does not close. #202 but gives users more options to try to mitigate it.