### PR TITLE
Fixing alarm volume response typo

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -293,7 +293,10 @@ class GlocaltokensApiClient:
                 device.set_do_not_disturb(enabled)
             else:
                 _LOGGER.debug(
-                    "Response not expected from Google Home device %s - %s",
+                    (
+                        "Unexpected response from Google Home device '%s' "
+                        "when fetching DND status - %s"
+                    ),
                     device.name,
                     response,
                 )
@@ -331,7 +334,7 @@ class GlocaltokensApiClient:
             polling=polling,
         )
         if response:
-            if JSON_NOTIFICATIONS_ENABLED in response:
+            if JSON_ALARM_VOLUME in response:
                 volume_raw = str(response[JSON_ALARM_VOLUME])
                 loaded_volume = float(volume_raw)
                 _LOGGER.debug(
@@ -344,7 +347,10 @@ class GlocaltokensApiClient:
                 device.set_alarm_volume(loaded_volume)
             else:
                 _LOGGER.debug(
-                    "Response not expected from Google Home device %s - %s",
+                    (
+                        "Unexpected response from Google Home device '%s' "
+                        "when fetching alarm volume setting - %s"
+                    ),
                     device.name,
                     response,
                 )


### PR DESCRIPTION
We discovered that there is a type in asserting response returned from alarm value endpoint that results in failing to fetch the alarm value setting.

Closes #282 