### PR TITLE
Using unique device_id received from glocaltokens==0.4.0

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -92,6 +92,7 @@ class GlocaltokensApiClient:
             google_devices = await self.hass.async_add_executor_job(_get_google_devices)
             self.google_devices = [
                 GoogleHomeDevice(
+                    device_id=device.device_id,
                     name=device.device_name,
                     auth_token=device.local_auth_token,
                     ip_address=device.ip_address,

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -21,10 +21,12 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
         self,
         coordinator: DataUpdateCoordinator,
         client: GlocaltokensApiClient,
+        device_id: str,
         device_name: str,
     ):
         super().__init__(coordinator)
         self.client = client
+        self.device_id = device_id
         self.device_name = device_name
 
     @property
@@ -41,7 +43,7 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{self.device_name}/{self.label}"
+        return f"{self.device_id}/{self.label}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/google_home/manifest.json
+++ b/custom_components/google_home/manifest.json
@@ -7,7 +7,7 @@
   "domain": "google_home",
   "issue_tracker": "https://github.com/leikoilja/ha-google-home/issues",
   "name": "Google Home",
-  "requirements": ["glocaltokens==0.3.1"],
+  "requirements": ["glocaltokens==0.4.0"],
   "version": "1.6.1",
   "zeroconf": ["_googlecast._tcp.local."],
   "iot_class": "cloud_polling"

--- a/custom_components/google_home/models.py
+++ b/custom_components/google_home/models.py
@@ -26,11 +26,13 @@ class GoogleHomeDevice:
 
     def __init__(
         self,
+        device_id: str,
         name: str,
         auth_token: str | None,
         ip_address: str | None = None,
         hardware: str | None = None,
     ):
+        self.device_id = device_id
         self.name = name
         self.auth_token = auth_token
         self.ip_address = ip_address

--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -45,6 +45,7 @@ async def async_setup_entry(
                 AlarmVolumeNumber(
                     coordinator,
                     client,
+                    device.device_id,
                     device.name,
                 )
             )

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -57,6 +57,7 @@ async def async_setup_entry(
             GoogleHomeDeviceSensor(
                 coordinator,
                 client,
+                device.device_id,
                 device.name,
             )
         )
@@ -65,11 +66,13 @@ async def async_setup_entry(
                 GoogleHomeAlarmsSensor(
                     coordinator,
                     client,
+                    device.device_id,
                     device.name,
                 ),
                 GoogleHomeTimersSensor(
                     coordinator,
                     client,
+                    device.device_id,
                     device.name,
                 ),
             ]
@@ -122,6 +125,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
         """Return the state attributes."""
         device = self.get_device()
         attributes: DeviceAttributes = {
+            "device_id": None,
             "device_name": self.device_name,
             "auth_token": None,
             "ip_address": None,
@@ -135,6 +139,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
     def get_device_attributes(device: GoogleHomeDevice) -> DeviceAttributes:
         """Device representation as dictionary"""
         return {
+            "device_id": device.device_id,
             "device_name": device.name,
             "auth_token": device.auth_token,
             "ip_address": device.ip_address,

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -36,6 +36,7 @@ async def async_setup_entry(
                 DoNotDisturbSwitch(
                     coordinator,
                     client,
+                    device.device_id,
                     device.name,
                 )
             )

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -51,6 +51,7 @@ class GoogleHomeTimerDict(TypedDict):
 class DeviceAttributes(TypedDict):
     """Typed dict for device attributes"""
 
+    device_id: str | None
     device_name: str
     auth_token: str | None
     ip_address: str | None

--- a/poetry.lock
+++ b/poetry.lock
@@ -301,7 +301,7 @@ test = ["coverage (>=4.0.0,<5.0.0)", "pytest (>=4)", "pytest-cov (>=2)", "flake8
 
 [[package]]
 name = "glocaltokens"
-version = "0.3.1"
+version = "0.4.0"
 description = "Tool to extract Google device local authentication tokens in Python"
 category = "main"
 optional = false
@@ -996,36 +996,24 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -1097,8 +1085,8 @@ flake8-use-fstring = [
     {file = "flake8-use-fstring-1.1.tar.gz", hash = "sha256:a0eea849ffe33fb6903c210c243c0f418da86a530e46cb13e64f1bdb045f22dc"},
 ]
 glocaltokens = [
-    {file = "glocaltokens-0.3.1-py3-none-any.whl", hash = "sha256:fd6ccaf6e756d9b63856f8c7b49cf4405371ca14d6872e16e27935118e0499a6"},
-    {file = "glocaltokens-0.3.1.tar.gz", hash = "sha256:69f9a376973e465c65f5057243222d2919d17aa1b881d0b55c97584d656e0864"},
+    {file = "glocaltokens-0.4.0-py3-none-any.whl", hash = "sha256:35771e38057ef68ce94224891e05aabece0e0acad2c28c1d8b77f48402fb94c9"},
+    {file = "glocaltokens-0.4.0.tar.gz", hash = "sha256:e27740d67b6170caf3241cd497e78f683ee71727b754469d7fc036ab1113b5aa"},
 ]
 gpsoauth = [
     {file = "gpsoauth-1.0.0-py3-none-any.whl", hash = "sha256:149c374863eec17cdac5279d57e4905592a9cd74cc34b7e58671cb19f9238f39"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-glocaltokens = "0.3.1"
+glocaltokens = "0.4.0"
 homeassistant = "2021.4.0"
 zeroconf = "^0.29.0"
 


### PR DESCRIPTION
`glocaltokens` v0.4.0 [implements](https://github.com/leikoilja/glocaltokens/pull/145) grabbing unique device id from foyer API 

This PR is utilising that `unique_id` for device id.
Closes #199 

This is probably a breaking change since it will require users to reload the integration so the devices receive new unique ID.
Note, after this is merged into `master` we need to extensively test it before releasing a new public release.