### PR TITLE
Remove data collection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@
    - [Running in Home Assistant Docker container](#running-in-home-assistant-docker-container)
 7. [Lovelace Cards](#lovelace-cards)
 8. [Node-RED Flows](#node-red-flows)
-9. [Diagnostic Data Collection](#diagnostic-data-collection)
-10. [Troubleshooting](#troubleshooting)
-11. [Contribution](#contribution)
-12. [Localization](#localization)
-13. [Credits](#credits)
+9. [Troubleshooting](#troubleshooting)
+10. [Contribution](#contribution)
+11. [Localization](#localization)
+12. [Credits](#credits)
 
 </details>
 
@@ -266,14 +265,6 @@ Make sure that you have your Home Assistant Container network set to `host`, as 
 
 - [Alarms & timers as actionable notifications](https://dev.to/mattieha/get-google-home-alarms-timers-as-notifications-i0m) by [@mattieha](https://github.com/mattieha)
 - [Broadcast ringing alarms & timers to other devices](https://dev.to/mattieha/broadcast-google-home-alarms-timers-3c13) by [@mattieha](https://github.com/mattieha)
-
-## Diagnostic Data Collection
-
-To make the integration better we are trying to be one step ahead of the game,
-working on catching and fixing errors before the user even knows about them.
-To do so, we are implementing anonymous diagnostic data collection.
-We will never collect any user sensitive data, only integration related
-warnings and errors. See related [developers discussion](https://github.com/leikoilja/ha-google-home/discussions/116).
 
 ## Troubleshooting
 

--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .api import GlocaltokensApiClient
 from .const import (
     CONF_ANDROID_ID,
-    CONF_DATA_COLLECTION,
     CONF_MASTER_TOKEN,
     CONF_PASSWORD,
     CONF_UPDATE_INTERVAL,
@@ -138,12 +137,6 @@ class GoogleHomeOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_UPDATE_INTERVAL, UPDATE_INTERVAL
                         ),
                     ): int,
-                    vol.Optional(
-                        CONF_DATA_COLLECTION,
-                        default=self.config_entry.options.get(
-                            CONF_DATA_COLLECTION, True
-                        ),
-                    ): bool,
                 }
             ),
         )

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -13,7 +13,6 @@ MANUFACTURER: Final = "google_home"
 
 ATTRIBUTION: Final = "json"
 ISSUE_URL: Final = "https://github.com/leikoilja/ha-google-home/issues"
-CONF_DATA_COLLECTION: Final = "data_collection"
 CONF_UPDATE_INTERVAL: Final = "update_interval"
 
 DATA_CLIENT: Final = "client"

--- a/custom_components/google_home/translations/ca.json
+++ b/custom_components/google_home/translations/ca.json
@@ -22,7 +22,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Permet la recol·lecta de dades de diagnòstic anònimes. Visita https://github.com/leikoilja/ha-google-home#diagnostic-data-collection (en anglès) per a més informació. Reinici necessari.",
           "update_interval": "Canvia l'interval d'actualització. Augmenteu-ho si teniu temps d’espera dels dispositius. Valor per defecte: 180 (segons)"
         }
       }

--- a/custom_components/google_home/translations/de.json
+++ b/custom_components/google_home/translations/de.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Stimme der anonymen Datenerfassung zu (weitere Informationen: https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Aktualisierungsintervall ändern. Erhöhen Sie diesen Wert, wenn Sie unter Zeitüberschreitungen der Geräte leiden. Standard: 180 (Sekunden)"
         }
       }

--- a/custom_components/google_home/translations/en.json
+++ b/custom_components/google_home/translations/en.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Allow anonymous diagnostic data collection (See https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Change update interval. Increase this if you are suffering from devices timing out. Default: 180 (Seconds)"
         }
       }

--- a/custom_components/google_home/translations/nb.json
+++ b/custom_components/google_home/translations/nb.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Tillat at anonym diagnostikkdata blir samla (se https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Endre oppdateringsintervall. Øk dette hvis du lider av tidsavbrudd for enheter. Standard: 180 (sekunder)"
         }
       }

--- a/custom_components/google_home/translations/nn.json
+++ b/custom_components/google_home/translations/nn.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Tillat at anonym diagnostikkdata vert samla (sjå https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Endre oppdateringsintervall. Øk dette hvis du lider av tidsavbrudd for enheter. Standard: 180 (sekunder)"
         }
       }

--- a/custom_components/google_home/translations/pt.json
+++ b/custom_components/google_home/translations/pt.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Permitir a recolha anónima de dados de diagnóstico (Ver https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Altere o intervalo de atualização. Aumente isso se você estiver sofrendo de tempo limite dos dispositivos. Padrão: 180 (segundos)"
         }
       }

--- a/custom_components/google_home/translations/ru.json
+++ b/custom_components/google_home/translations/ru.json
@@ -21,7 +21,6 @@
     "step": {
       "init": {
         "data": {
-          "data_collection": "Разрешить анонимный сбор данных для диагностики (см. https://github.com/leikoilja/ha-google-home#diagnostic-data-collection).",
           "update_interval": "Изменить интервал обновления. Увеличьте это значение, если у вас истекло время ожидания устройств. По умолчанию: 180 (секунд)"
         }
       }

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -95,7 +95,6 @@ class ConfigFlowDict(TypedDict):
 class OptionsFlowDict(TypedDict):
     """Typed dict for options flow handler"""
 
-    data_collection: bool
     update_interval: int
 
 


### PR DESCRIPTION
Data collection is not implemented and I don't see any value in having unused option.

It turns out user reports and logs are sufficient for debugging.

Can be reverted once if at some point we decide to implement it.