### PR TITLE
Use admin token for publishing release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,4 +31,4 @@ jobs:
         run: |
           poetry run python script/publish_release.py
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
We need more powerful token to be able to push updated `manifest.json` to the protected branch.