### PR TITLE
Do not format manifest.json with prettier

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "image": "ludeeus/container:integration",
   "name": "Google-Home community driven integration",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: check-added-large-files
+      - id: check-json
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -45,6 +46,7 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
+        exclude: ^custom_components/google_home/manifest\.json$
   - repo: https://github.com/cdce8p/python-typing-update
     rev: v0.3.3
     hooks:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,9 +1,7 @@
 {
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
-      // Example of attaching to local debug server
       "name": "Python: Attach Local",
       "type": "python",
       "request": "attach",
@@ -19,7 +17,6 @@
       ]
     },
     {
-      // Example of attaching to my production server
       "name": "Python: Attach Remote",
       "type": "python",
       "request": "attach",


### PR DESCRIPTION
It turns out prettier formats JSON differently than `json.dumps`: https://github.com/leikoilja/ha-google-home/runs/3524470666

Let's only check that JSON is valid with `check-json` hook and exclude `manifest.json` from formatting.
It'll be rewritten by publishing script on every release anyway.