### PR TITLE
Correctly change admin enforcement in publish script

### DIFF
--- a/script/publish_release.py
+++ b/script/publish_release.py
@@ -38,7 +38,7 @@ def update_version(repo: Repository, version: str) -> None:
     updated_manifest = json.dumps(manifest_json, indent=2) + "\n"
     branch = repo.get_branch("master")
     # Disable branch protection before commit
-    branch.edit_protection(enforce_admins=False)
+    branch.remove_admin_enforcement()
     repo.update_file(
         path=manifest.path,
         message=f"Release v{version}",
@@ -46,7 +46,7 @@ def update_version(repo: Repository, version: str) -> None:
         sha=manifest.sha,
     )
     # Re-enable branch protection
-    branch.edit_protection(enforce_admins=True)
+    branch.set_admin_enforcement()
 
 
 def publish_release(release: GitRelease) -> None:


### PR DESCRIPTION
`edit_protection()` actually rewrites all settings and not setting them clears them out.

This should preserve current settings and change only admin enforcement bit.