### PR TITLE
Adding Number to the list of initialised platforms

### DIFF
--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -36,7 +36,8 @@ BINARY_SENSOR_DEVICE_CLASS: Final = "connectivity"
 # Platforms
 SENSOR: Final = "sensor"
 SWITCH: Final = "switch"
-PLATFORMS: Final = [SENSOR, SWITCH]
+NUMBER: Final = "number"
+PLATFORMS: Final = [SENSOR, SWITCH, NUMBER]
 
 # Services
 SERVICE_REBOOT: Final = "reboot_device"


### PR DESCRIPTION
The `number` platform is added in the integration to be able to set alarm volume, however it is never initialized or added to the list of entities. The reason for that is that in integration `__init__` we run -> `hass.config_entries.async_setup_platforms(entry, PLATFORMS)`  that is setting up platforms and `PLATFORMS` is missing `number` 

Closes #314 