### PR TITLE
Clarify that Logger service needs to be enabled & configured in yaml mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,11 @@ Here are the steps to generate useful log data:
 1. Temporary log level change.
    1. Visit [Home Assistant Developer Services Tool](https://my.home-assistant.io/redirect/developer_services/).
    2. Choose `Logger: Set level` from the **Service** menu. (the [Logger service](https://www.home-assistant.io/integrations/logger/) needs to be enabled for this)
-   3. Under **Service data** paste the following:
+   3. Go to YAML mode and paste the following (starting on line 2):
       ```yaml
-      custom_components.google_home: debug
-      glocaltokens: debug
+      data:
+        custom_components.google_home: debug
+        glocaltokens: debug
       ```
    4. Click **Call Service**.
 2. Read the log information.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Here are the steps to generate useful log data:
 
 1. Temporary log level change.
    1. Visit [Home Assistant Developer Services Tool](https://my.home-assistant.io/redirect/developer_services/).
-   2. Choose `Logger: Set level` from the **Service** menu.
+   2. Choose `Logger: Set level` from the **Service** menu. (the [Logger service](https://www.home-assistant.io/integrations/logger/) needs to be enabled for this)
    3. Under **Service data** paste the following:
       ```yaml
       custom_components.google_home: debug


### PR DESCRIPTION
Logger: Set level only appears if `logger:` is defined in the configuration.yaml