### PR TITLE
Move attributes to device model and remove integration attribute

### DIFF
--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -9,7 +9,7 @@ from homeassistant.util.dt import DATE_STR_FORMAT
 NAME: Final = "Google Home community driven integration"
 DOMAIN: Final = "google_home"
 DOMAIN_DATA: Final = f"{DOMAIN}_data"
-MANUFACTURER: Final = "google_home"
+MANUFACTURER: Final = "Google Home"
 
 ATTRIBUTION: Final = "json"
 ISSUE_URL: Final = "https://github.com/leikoilja/ha-google-home/issues"

--- a/custom_components/google_home/entity.py
+++ b/custom_components/google_home/entity.py
@@ -23,11 +23,13 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
         client: GlocaltokensApiClient,
         device_id: str,
         device_name: str,
+        device_model: str,
     ):
         super().__init__(coordinator)
         self.client = client
         self.device_id = device_id
         self.device_name = device_name
+        self.device_model = device_model
 
     @property
     @abstractmethod
@@ -51,6 +53,7 @@ class GoogleHomeBaseEntity(CoordinatorEntity, ABC):
             "identifiers": {(DOMAIN, self.device_id)},
             "name": f"{DEFAULT_NAME} {self.device_name}",
             "manufacturer": MANUFACTURER,
+            "model": self.device_model,
         }
 
     def get_device(self) -> GoogleHomeDevice | None:

--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -43,10 +43,7 @@ async def async_setup_entry(
         if device.auth_token and device.available:
             numbers.append(
                 AlarmVolumeNumber(
-                    coordinator,
-                    client,
-                    device.device_id,
-                    device.name,
+                    coordinator, client, device.device_id, device.name, device.hardware
                 )
             )
 

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
                 client,
                 device.device_id,
                 device.name,
+                device.hardware,
             )
         )
         if device.auth_token and device.available:
@@ -68,12 +69,14 @@ async def async_setup_entry(
                     client,
                     device.device_id,
                     device.name,
+                    device.hardware,
                 ),
                 GoogleHomeTimersSensor(
                     coordinator,
                     client,
                     device.device_id,
                     device.name,
+                    device.hardware,
                 ),
             ]
     async_add_devices(sensors)
@@ -129,9 +132,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
             "device_name": self.device_name,
             "auth_token": None,
             "ip_address": None,
-            "hardware": None,
             "available": False,
-            "integration": DOMAIN,
         }
         return self.get_device_attributes(device) if device else attributes
 
@@ -143,9 +144,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
             "device_name": device.name,
             "auth_token": device.auth_token,
             "ip_address": device.ip_address,
-            "hardware": device.hardware,
             "available": device.available,
-            "integration": DOMAIN,
         }
 
     async def async_reboot_device(self) -> None:
@@ -196,7 +195,6 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             "next_alarm_status": self._get_next_alarm_status(),
             "alarm_volume": self._get_alarm_volume(),
             "alarms": self._get_alarms_data(),
-            "integration": DOMAIN,
         }
 
     def _get_next_alarm_status(self) -> str:
@@ -283,7 +281,6 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
         return {
             "next_timer_status": self._get_next_timer_status(),
             "timers": self._get_timers_data(),
-            "integration": DOMAIN,
         }
 
     def _get_next_timer_status(self) -> str:

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -39,6 +39,7 @@ async def async_setup_entry(
                     client,
                     device.device_id,
                     device.name,
+                    device.hardware,
                 )
             )
 

--- a/custom_components/google_home/types.py
+++ b/custom_components/google_home/types.py
@@ -55,9 +55,7 @@ class DeviceAttributes(TypedDict):
     device_name: str
     auth_token: str | None
     ip_address: str | None
-    hardware: str | None
     available: bool
-    integration: str
 
 
 class AlarmsAttributes(TypedDict):
@@ -66,7 +64,6 @@ class AlarmsAttributes(TypedDict):
     next_alarm_status: str
     alarm_volume: float
     alarms: list[GoogleHomeAlarmDict]
-    integration: str
 
 
 class TimersAttributes(TypedDict):
@@ -74,7 +71,6 @@ class TimersAttributes(TypedDict):
 
     next_timer_status: str
     timers: list[GoogleHomeTimerDict]
-    integration: str
 
 
 class DeviceInfo(TypedDict):
@@ -83,6 +79,7 @@ class DeviceInfo(TypedDict):
     identifiers: set[tuple[str, str]]
     name: str
     manufacturer: str
+    model: str
 
 
 class ConfigFlowDict(TypedDict):


### PR DESCRIPTION
Just a bit of cleanup 😄 

- Moves `hardware` attribute to `device_info`.
- Removes `integration` attribute as the integration is specified in `device_info`
- Change `MANUFACTURER` to human-readable instead as this is the name shown in the UI and should not be `google_home` but Google Home.