### PR TITLE
Add explanation for server and devices not on the same network

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ If you get the following error for ***all*** of your devices:
 2021-11-28 16:13:20 DEBUG (MainThread) [custom_components.google_home] Failed to fetch timers/alarms information from device xxx. We could not determine its IP address, the device is either offline or is not compatible Google Home device. Will try again later.
 ```
 
-I may be that your device and Home Assistant's installation are not on the same network.
+It may be that your device and Home Assistant installation are not on the same network.
 
 The integration works by connecting to the Google's servers to authenticate and get the authorisation keys for controlling these devices, but after that, all the requests are made locally, so it's required that the server and devices are on the same network. You can use a VPN or setup routing between each network to overcome this issue.
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ If you get the following error for ***all*** of your devices:
 
 I may be that your device and Home Assistant's installation are not on the same network.
 
-The integration works by connecting to the Google's servers to authenticate and get the authorisation keys for controlling the devices, but after that, all the requests are made locally, so it's required that the server and devices are on the same network. You can use a VPN to overcome this issue.
+The integration works by connecting to the Google's servers to authenticate and get the authorisation keys for controlling these devices, but after that, all the requests are made locally, so it's required that the server and devices are on the same network. You can use a VPN or setup routing between each network to overcome this issue.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,16 @@ If unsure, please check what account you are using in the _Google Home_ app and 
 
 If you can see your devices, and they all seem correct, but the alarms/timers sensors do not appear, or appear empty try restarting the Google Home device, Home Assistant, and reinstalling the integration.
 
+### Device offline or not compatible message (#402)
+
+If you get the following error for all of your devices:
+```
+2021-11-28 16:13:20 DEBUG (MainThread) [custom_components.google_home] Failed to fetch timers/alarms information from device xxx. We could not determine its IP address, the device is either offline or is not compatible Google Home device. Will try again later.
+```
+I may be that your device and Home Assistant's installation are not on the same network.
+
+The integration works by connecting to the Google's servers to authenticate and get the authorisation keys for controlling the devices, but after that, all the requests are made locally, so it's required that the server and devices are on the same network. You can use a VPN to overcome this issue.
+
 ## Contribution
 
 If you encounter issues or have any suggestions consider opening issues and contributing through PR.

--- a/README.md
+++ b/README.md
@@ -370,9 +370,11 @@ If you can see your devices, and they all seem correct, but the alarms/timers se
 ### Device offline or not compatible message (#402)
 
 If you get the following error for all of your devices:
+
 ```
 2021-11-28 16:13:20 DEBUG (MainThread) [custom_components.google_home] Failed to fetch timers/alarms information from device xxx. We could not determine its IP address, the device is either offline or is not compatible Google Home device. Will try again later.
 ```
+
 I may be that your device and Home Assistant's installation are not on the same network.
 
 The integration works by connecting to the Google's servers to authenticate and get the authorisation keys for controlling the devices, but after that, all the requests are made locally, so it's required that the server and devices are on the same network. You can use a VPN to overcome this issue.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you can see your devices, and they all seem correct, but the alarms/timers se
 
 ### Device offline or not compatible message (#402)
 
-If you get the following error for all of your devices:
+If you get the following error for ***all*** of your devices:
 
 ```
 2021-11-28 16:13:20 DEBUG (MainThread) [custom_components.google_home] Failed to fetch timers/alarms information from device xxx. We could not determine its IP address, the device is either offline or is not compatible Google Home device. Will try again later.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you can see your devices, and they all seem correct, but the alarms/timers se
 
 ### Device offline or not compatible message (#402)
 
-If you get the following error for ***all*** of your devices:
+If you get the following error for **_all_** of your devices:
 
 ```
 2021-11-28 16:13:20 DEBUG (MainThread) [custom_components.google_home] Failed to fetch timers/alarms information from device xxx. We could not determine its IP address, the device is either offline or is not compatible Google Home device. Will try again later.


### PR DESCRIPTION
Added an explanation on README for having some reference over #402 and informing that the device and the Home Assistant installation must be on the same network.