### PR TITLE
Add a reminder to use github action for releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: "v$RESOLVED_VERSION"
+name-template: "RELEASE WITH GITHUB ACTIONS! v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features"

--- a/script/publish_release.py
+++ b/script/publish_release.py
@@ -22,7 +22,7 @@ def main() -> int:
     if not release.draft:
         print("The latest release is not a draft!")
         return 1
-    version = release.title.lstrip("v")
+    version = release.title.split()[-1].lstrip("v")
     update_version(repo, version)
     publish_release(release)
     return 0
@@ -53,7 +53,7 @@ def publish_release(release: GitRelease) -> None:
     """Publish draft release"""
     print("Publishing new release...")
     release.update_release(
-        name=release.title,
+        name=release.title.split()[-1],
         message=release.body,
         draft=False,
     )


### PR DESCRIPTION
Change title to remind about that, draft should be visible only to collaborators. Script will then cut this message from the final release.