### PR TITLE
Use permanent link for installs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,5 +420,5 @@ If you want to translate the project to your own language, follow the [Localizat
 [releases]: https://github.com/leikoilja/ha-google-home/releases
 [workflow-shield]: https://img.shields.io/github/workflow/status/leikoilja/ha-google-home/Linting?style=for-the-badge
 [workflow]: https://github.com/leikoilja/ha-google-home/actions
-[installs-shield]: https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fgoogle-home-installs-for-shield-io-k12ch0ykl3ot.runkit.sh%2F
+[installs-shield]: https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Frunkit.io%2Fkapji%2Fgoogle-home-installs-for-shield-io%2F3.0.0
 [installs]: https://analytics.home-assistant.io/custom_integrations.json


### PR DESCRIPTION
It'll be redirected to the current endpoint.