### PR TITLE
Use EntityCategory enum instead of strings

### DIFF
--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -5,8 +5,9 @@ import logging
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_CONFIG, PERCENTAGE
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -57,7 +58,7 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
     """Google Home Alarm Volume Number entity."""
 
     _attr_unit_of_measurement = PERCENTAGE
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     @property
     def label(self) -> str:

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -8,12 +8,11 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEVICE_CLASS_TIMESTAMP,
-    ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -113,7 +112,7 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
     """Google Home Device sensor."""
 
     _attr_icon = ICON_TOKEN
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def label(self) -> str:

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -6,10 +6,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    DEVICE_CLASS_TIMESTAMP,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import DEVICE_CLASS_TIMESTAMP, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity, EntityCategory

--- a/custom_components/google_home/switch.py
+++ b/custom_components/google_home/switch.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -54,7 +54,7 @@ class DoNotDisturbSwitch(GoogleHomeBaseEntity, SwitchEntity):
     """Google Home Do Not Disturb switch."""
 
     _attr_icon = ICON_DO_NOT_DISTURB
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     @property
     def label(self) -> str:


### PR DESCRIPTION
Using the entity category strings doesn't work anymore starting in `2022.4`. Using the enums instead fixes #503 .

The enums have been accepted since `2021.12` ([PR](https://github.com/home-assistant/core/pull/60720)) which covers your supported versions so it is safe to make immediately, don't have to wait for `2022.4`.