### PR TITLE
Stop overriding deprecated methods of NumberEntity

### DIFF
--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -57,9 +57,11 @@ async def async_setup_entry(
 class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
     """Google Home Alarm Volume Number entity."""
 
-    _attr_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.CONFIG
-
+    _attr_native_min_value, _attr_native_max_value = (0, 100)
+    _attr_native_step = 1
+    
     @property
     def label(self) -> str:
         """Label to use for name and unique id."""
@@ -81,23 +83,8 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
         return ICON_ALARM_VOLUME_HIGH
 
     @property
-    def min_value(self) -> int:
-        """Return the minimum value for the volume"""
-        return 0
-
-    @property
-    def max_value(self) -> int:
-        """Return the minimum value for the volume"""
-        return 100
-
-    @property
-    def step(self) -> int:
-        """Return the step value for the volume"""
-        return 1
-
-    @property
-    def value(self) -> int:
-        """Return the current volume value"""
+    def native_value(self) -> float:
+        """Return the current volume value."""
         device = self.get_device()
 
         if device is None:
@@ -106,7 +93,7 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
         volume = device.get_alarm_volume()
         return volume
 
-    async def async_set_value(self, value: int) -> None:  # type: ignore
+    async def async_set_native_value(self, value: int) -> None:  # type: ignore
         """Sets the alarm volume"""
         device = self.get_device()
         if device is None:
@@ -114,3 +101,4 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
             return
 
         await self.client.update_alarm_volume(device=device, volume=value)
+

--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -61,7 +61,7 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_native_min_value, _attr_native_max_value = (0, 100)
     _attr_native_step = 1
-    
+
     @property
     def label(self) -> str:
         """Label to use for name and unique id."""
@@ -93,7 +93,7 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
         volume = device.get_alarm_volume()
         return volume
 
-    async def async_set_native_value(self, value: int) -> None:  # type: ignore
+    async def async_set_native_value(self, value: int) -> None:
         """Sets the alarm volume"""
         device = self.get_device()
         if device is None:
@@ -101,4 +101,3 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
             return
 
         await self.client.update_alarm_volume(device=device, volume=value)
-

--- a/custom_components/google_home/number.py
+++ b/custom_components/google_home/number.py
@@ -59,7 +59,8 @@ class AlarmVolumeNumber(GoogleHomeBaseEntity, NumberEntity):
 
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value, _attr_native_max_value = (0, 100)
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
     _attr_native_step = 1
 
     @property


### PR DESCRIPTION
Fixes: https://github.com/leikoilja/ha-google-home/issues/562

Very minimal changes to get rid of the deprecation warnings regarding overwriting deprecated methods of the NumberEntity. 

Note, [the default values](https://github.com/home-assistant/core/blob/dev/homeassistant/components/number/const.py#L10-L12) for min/max/step are the same but with one decimal, think I prefer defining them explicitly to not depend on the default values stat the same, but would be happy to change it if you prefer the default values.

Expected/tested behaviour: 
- No more deprecation warning show up in the logs
- No changes in behaviour

