### PR TITLE
Fix services schema and improve selectors

### DIFF
--- a/custom_components/google_home/services.yaml
+++ b/custom_components/google_home/services.yaml
@@ -3,14 +3,10 @@
 reboot_device:
   name: Reboot device
   description: Reboot a Google Home device.
-  fields:
-    entity_id:
-      name: Entity
-      description: Represents a Google Home device (sensor.xxxx_device).
-      example: "sensor.kitchen_device"
-      required: true
-      selector:
-        text:
+  target:
+    entity:
+      domain: sensor
+      integration: google_home
 
 delete_alarm:
   name: Delete alarm
@@ -22,7 +18,9 @@ delete_alarm:
       example: "sensor.kitchen_alarms"
       required: true
       selector:
-        text:
+        entity:
+          domain: sensor
+          integration: google_home
     alarm_id:
       name: Alarm ID
       description: ID of an alarm (alarm/xxx).
@@ -41,7 +39,9 @@ delete_timer:
       example: "sensor.kitchen_timers"
       required: true
       selector:
-        text:
+        entity:
+          domain: sensor
+          integration: google_home
     timer_id:
       name: Timer ID
       description: ID of a timer (timer/xxx).


### PR DESCRIPTION
* Changing `dict` to `vol.Schema` changed behaviour of services and they lost automatic `entity_id` field. Bring it back.
* `type: ignore` can be removed once https://github.com/home-assistant/core/pull/103777 is merged and released.
* Add selectors to filter entities from `google_home` integration.
* Allow to reboot multiple devices with single `google.home.reboot` call.
* Modernise code base a bit, e.g. use `async_get_current_platform()` and pass async functions directly to `async_register_entity_service` which also changes behaviour a bit and they start receiving `ServiceCall`.
* Tested all services locally this time.

Fixes #786, #790