### PR TITLE
Fix poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 name = "google_home"
 version = "0.0.0"
 description = "Home Assistant Google Home community integration"
-authors = ["Ilja Leiko <leikoilja@gmail.com"]
+authors = ["Ilja Leiko <leikoilja@gmail.com>"]
 license = "MIT"
 readme = "README.md"
+packages = [{include = "google_home", from = "custom_components"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
New version of poetry started to verify this.
* Authors was missing `>`
* Non standard layout causes `No file/folder found for package google-home`