### PR TITLE
Allow Refreshing Devices During Deletes or Manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,16 +155,16 @@ service: google_home.delete_alarm
 data:
   entity_id: sensor.kitchen_alarms
   timer_id: alarm/47dc1fa0-5ec0-2cc7-9ead-a94b85e22769
-  force_refresh: true
+  skip_refresh: true
 ```
 
 #### Key Descriptions
 
-| Key             | Example                                      | Description                                      |
-| --------------- | -------------------------------------------- | ------------------------------------------------ |
-| `entity_id`     | `sensor.kitchen_alarms`                      | Entity name of a Google Home alarms sensor.      |
-| `alarm_id`      | `alarm/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of an alarm. See alarms description above.    |
-| `force_refresh` | `true`                                       | Boolean to force refreshing Google Home devices. |
+| Key            | Example                                      | Description                                     |
+| -------------- | -------------------------------------------- | ----------------------------------------------- |
+| `entity_id`    | `sensor.kitchen_alarms`                      | Entity name of a Google Home alarms sensor.     |
+| `alarm_id`     | `alarm/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of an alarm. See alarms description above.   |
+| `skip_refresh` | `true`                                       | Boolean to skip refreshing Google Home devices. |
 
 ### Delete timer
 
@@ -175,15 +175,16 @@ service: google_home.delete_timer
 data:
   entity_id: sensor.kitchen_timers
   timer_id: timer/47dc1fa0-5ec0-2cc7-9ead-a94b85e22769
+  skip_refresh: true
 ```
 
 #### Key Descriptions
 
-| Key             | Example                                      | Description                                      |
-| --------------- | -------------------------------------------- | ------------------------------------------------ |
-| `entity_id`     | `sensor.kitchen_timers`                      | Entity name of a Google Home timers sensor.      |
-| `timer_id`      | `timer/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of a timer. See timers description above.     |
-| `force_refresh` | `true`                                       | Boolean to force refreshing Google Home devices. |
+| Key            | Example                                      | Description                                     |
+| -------------- | -------------------------------------------- | ----------------------------------------------- |
+| `entity_id`    | `sensor.kitchen_timers`                      | Entity name of a Google Home timers sensor.     |
+| `timer_id`     | `timer/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of a timer. See timers description above.    |
+| `skip_refresh` | `true`                                       | Boolean to skip refreshing Google Home devices. |
 
 ### Reboot device
 

--- a/README.md
+++ b/README.md
@@ -155,14 +155,16 @@ service: google_home.delete_alarm
 data:
   entity_id: sensor.kitchen_alarms
   timer_id: alarm/47dc1fa0-5ec0-2cc7-9ead-a94b85e22769
+  force_refresh: true
 ```
 
 #### Key Descriptions
 
-| Key         | Example                                      | Description                                   |
-| ----------- | -------------------------------------------- | --------------------------------------------- |
-| `entity_id` | `sensor.kitchen_alarms`                      | Entity name of a Google Home alarms sensor.   |
-| `alarm_id`  | `alarm/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of an alarm. See alarms description above. |
+| Key             | Example                                      | Description                                      |
+| --------------- | -------------------------------------------- | ------------------------------------------------ |
+| `entity_id`     | `sensor.kitchen_alarms`                      | Entity name of a Google Home alarms sensor.      |
+| `alarm_id`      | `alarm/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of an alarm. See alarms description above.    |
+| `force_refresh` | `true`                                       | Boolean to force refreshing Google Home devices. |
 
 ### Delete timer
 
@@ -177,10 +179,11 @@ data:
 
 #### Key Descriptions
 
-| Key         | Example                                      | Description                                  |
-| ----------- | -------------------------------------------- | -------------------------------------------- |
-| `entity_id` | `sensor.kitchen_timers`                      | Entity name of a Google Home timers sensor.  |
-| `timer_id`  | `timer/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of a timer. See timers description above. |
+| Key             | Example                                      | Description                                      |
+| --------------- | -------------------------------------------- | ------------------------------------------------ |
+| `entity_id`     | `sensor.kitchen_timers`                      | Entity name of a Google Home timers sensor.      |
+| `timer_id`      | `timer/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51` | ID of a timer. See timers description above.     |
+| `force_refresh` | `true`                                       | Boolean to force refreshing Google Home devices. |
 
 ### Reboot device
 
@@ -199,6 +202,16 @@ data:
 | Key         | Example                 | Description                                 |
 | ----------- | ----------------------- | ------------------------------------------- |
 | `entity_id` | `sensor.kitchen_device` | Entity name of a Google Home device sensor. |
+
+### Refresh devices
+
+Note: Resets the timer for automatic polling to refresh devices.
+
+#### Example
+
+```yaml
+service: google_home.refresh_devices
+```
 
 ## Getting Started
 

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -42,8 +42,10 @@ PLATFORMS: Final = [SENSOR, SWITCH, NUMBER]
 SERVICE_REBOOT: Final = "reboot_device"
 SERVICE_DELETE_ALARM: Final = "delete_alarm"
 SERVICE_DELETE_TIMER: Final = "delete_timer"
+SERVICE_REFRESH: Final = "refresh_devices"
 SERVICE_ATTR_ALARM_ID: Final = "alarm_id"
 SERVICE_ATTR_TIMER_ID: Final = "timer_id"
+SERVICE_ATTR_FORCE_REFRESH: Final = "force_refresh"
 
 # Configuration and options
 CONF_ANDROID_ID: Final = "android_id"

--- a/custom_components/google_home/const.py
+++ b/custom_components/google_home/const.py
@@ -44,8 +44,8 @@ SERVICE_DELETE_ALARM: Final = "delete_alarm"
 SERVICE_DELETE_TIMER: Final = "delete_timer"
 SERVICE_REFRESH: Final = "refresh_devices"
 SERVICE_ATTR_ALARM_ID: Final = "alarm_id"
+SERVICE_ATTR_SKIP_REFRESH: Final = "skip_refresh"
 SERVICE_ATTR_TIMER_ID: Final = "timer_id"
-SERVICE_ATTR_FORCE_REFRESH: Final = "force_refresh"
 
 # Configuration and options
 CONF_ANDROID_ID: Final = "android_id"

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -90,17 +90,21 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_DELETE_ALARM,
         {
-            vol.Required(SERVICE_ATTR_ALARM_ID): cv.string,
-            vol.Optional(SERVICE_ATTR_FORCE_REFRESH): cv.boolean,
+            vol.Required(SERVICE_ATTR_ALARM_ID): cv.string,  # type: ignore[dict-item]
+            vol.Optional(
+                SERVICE_ATTR_FORCE_REFRESH
+            ): cv.boolean,  # type: ignore[dict-item]
         },
         GoogleHomeAlarmsSensor.async_delete_alarm,
     )
 
     platform.async_register_entity_service(
         SERVICE_DELETE_TIMER,
-        {
-            vol.Required(SERVICE_ATTR_TIMER_ID): cv.string,
-            vol.Optional(SERVICE_ATTR_FORCE_REFRESH): cv.boolean,
+        {  # types: ignore[dict]
+            vol.Required(SERVICE_ATTR_TIMER_ID): cv.string,  # type: ignore[dict-item]
+            vol.Optional(
+                SERVICE_ATTR_FORCE_REFRESH
+            ): cv.boolean,  # type: ignore[dict-item]
         },
         GoogleHomeTimersSensor.async_delete_timer,
     )
@@ -333,4 +337,5 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=timer_id)
         if call.data[SERVICE_ATTR_FORCE_REFRESH]:
+            _LOGGER.debug("Refreshing Devices")
             await self.coordinator.async_request_refresh()

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -26,7 +26,7 @@ from .const import (
     LABEL_DEVICE,
     LABEL_TIMERS,
     SERVICE_ATTR_ALARM_ID,
-    SERVICE_ATTR_FORCE_REFRESH,
+    SERVICE_ATTR_SKIP_REFRESH,
     SERVICE_ATTR_TIMER_ID,
     SERVICE_DELETE_ALARM,
     SERVICE_DELETE_TIMER,
@@ -92,7 +92,7 @@ async def async_setup_entry(
         {
             vol.Required(SERVICE_ATTR_ALARM_ID): cv.string,  # type: ignore[dict-item]
             vol.Optional(
-                SERVICE_ATTR_FORCE_REFRESH
+                SERVICE_ATTR_SKIP_REFRESH
             ): cv.boolean,  # type: ignore[dict-item]
         },
         GoogleHomeAlarmsSensor.async_delete_alarm,
@@ -100,10 +100,10 @@ async def async_setup_entry(
 
     platform.async_register_entity_service(
         SERVICE_DELETE_TIMER,
-        {  # types: ignore[dict]
+        {
             vol.Required(SERVICE_ATTR_TIMER_ID): cv.string,  # type: ignore[dict-item]
             vol.Optional(
-                SERVICE_ATTR_FORCE_REFRESH
+                SERVICE_ATTR_SKIP_REFRESH
             ): cv.boolean,  # type: ignore[dict-item]
         },
         GoogleHomeTimersSensor.async_delete_timer,
@@ -260,7 +260,7 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=alarm_id)
-        if call.data[SERVICE_ATTR_FORCE_REFRESH]:
+        if not call.data[SERVICE_ATTR_SKIP_REFRESH]:
             await self.coordinator.async_request_refresh()
 
 
@@ -336,6 +336,6 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=timer_id)
-        if call.data[SERVICE_ATTR_FORCE_REFRESH]:
+        if not call.data[SERVICE_ATTR_SKIP_REFRESH]:
             _LOGGER.debug("Refreshing Devices")
             await self.coordinator.async_request_refresh()

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -26,10 +26,12 @@ from .const import (
     LABEL_DEVICE,
     LABEL_TIMERS,
     SERVICE_ATTR_ALARM_ID,
+    SERVICE_ATTR_FORCE_REFRESH,
     SERVICE_ATTR_TIMER_ID,
     SERVICE_DELETE_ALARM,
     SERVICE_DELETE_TIMER,
     SERVICE_REBOOT,
+    SERVICE_REFRESH,
 )
 from .entity import GoogleHomeBaseEntity
 from .models import GoogleHomeAlarmStatus, GoogleHomeDevice, GoogleHomeTimerStatus
@@ -87,13 +89,19 @@ async def async_setup_entry(
     # Services
     platform.async_register_entity_service(
         SERVICE_DELETE_ALARM,
-        {vol.Required(SERVICE_ATTR_ALARM_ID): cv.string},  # type: ignore[dict-item]
+        {
+            vol.Required(SERVICE_ATTR_ALARM_ID): cv.string,
+            vol.Optional(SERVICE_ATTR_FORCE_REFRESH): cv.boolean,
+        },
         GoogleHomeAlarmsSensor.async_delete_alarm,
     )
 
     platform.async_register_entity_service(
         SERVICE_DELETE_TIMER,
-        {vol.Required(SERVICE_ATTR_TIMER_ID): cv.string},  # type: ignore[dict-item]
+        {
+            vol.Required(SERVICE_ATTR_TIMER_ID): cv.string,
+            vol.Optional(SERVICE_ATTR_FORCE_REFRESH): cv.boolean,
+        },
         GoogleHomeTimersSensor.async_delete_timer,
     )
 
@@ -101,6 +109,12 @@ async def async_setup_entry(
         SERVICE_REBOOT,
         {},
         GoogleHomeDeviceSensor.async_reboot_device,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_REFRESH,
+        {},
+        GoogleHomeDeviceSensor.async_refresh_devices,
     )
 
     return True
@@ -155,6 +169,10 @@ class GoogleHomeDeviceSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.reboot_google_device(device)
+
+    async def async_refresh_devices(self, _call: ServiceCall) -> None:
+        """Refresh the devices."""
+        await self.coordinator.async_request_refresh()
 
 
 class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
@@ -238,6 +256,8 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=alarm_id)
+        if call.data[SERVICE_ATTR_FORCE_REFRESH]:
+            await self.coordinator.async_request_refresh()
 
 
 class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
@@ -312,3 +332,5 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=timer_id)
+        if call.data[SERVICE_ATTR_FORCE_REFRESH]:
+            await self.coordinator.async_request_refresh()

--- a/custom_components/google_home/services.yaml
+++ b/custom_components/google_home/services.yaml
@@ -15,6 +15,12 @@ delete_alarm:
         entity:
           domain: sensor
           integration: google_home
+    force_refresh:
+      example: true
+      default: false
+      required: false
+      selector:
+        boolean:
     alarm_id:
       example: "alarm/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51"
       required: true
@@ -30,8 +36,16 @@ delete_timer:
         entity:
           domain: sensor
           integration: google_home
+    force_refresh:
+      example: true
+      default: false
+      required: false
+      selector:
+        boolean:
     timer_id:
       example: "timer/6ed06a56-8a58-c6e3-a7d4-03f92c9d8a51"
       required: true
       selector:
         text:
+
+refresh_devices:

--- a/custom_components/google_home/services.yaml
+++ b/custom_components/google_home/services.yaml
@@ -16,8 +16,8 @@ delete_alarm:
           domain: sensor
           integration: google_home
     skip_refresh:
-      example: false
-      default: true
+      example: true
+      default: false
       required: false
       selector:
         boolean:
@@ -37,8 +37,8 @@ delete_timer:
           domain: sensor
           integration: google_home
     skip_refresh:
-      example: false
-      default: true
+      example: true
+      default: false
       required: false
       selector:
         boolean:

--- a/custom_components/google_home/services.yaml
+++ b/custom_components/google_home/services.yaml
@@ -15,9 +15,9 @@ delete_alarm:
         entity:
           domain: sensor
           integration: google_home
-    force_refresh:
-      example: true
-      default: false
+    skip_refresh:
+      example: false
+      default: true
       required: false
       selector:
         boolean:
@@ -36,9 +36,9 @@ delete_timer:
         entity:
           domain: sensor
           integration: google_home
-    force_refresh:
-      example: true
-      default: false
+    skip_refresh:
+      example: false
+      default: true
       required: false
       selector:
         boolean:

--- a/custom_components/google_home/translations/ca.json
+++ b/custom_components/google_home/translations/ca.json
@@ -37,6 +37,10 @@
           "description": "ID de l'alarma (alarm/xxx).",
           "name": "ID de l'alarma"
         },
+        "skip_refresh": {
+          "description": "Omet l'actualització dels dispositius de Google Home després d'haver suprimit una alarma.",
+          "name": "Omet l'actualització"
+        },
         "entity_id": {
           "description": "Representa un dispositiu Google Home (sensor.xxxx_alarms).",
           "name": "Entitat"
@@ -51,6 +55,10 @@
           "description": "ID del temporitzador (timer/xxx).",
           "name": "ID del temporitzador"
         },
+        "skip_refresh": {
+          "description": "Omet l'actualització dels dispositius de Google Home després d'haver suprimit un temporitzador.",
+          "name": "Omet l'actualització"
+        },
         "entity_id": {
           "description": "Representa un dispositiu Google Home (sensor.xxxx_alarms).",
           "name": "Entitat"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Reinicia un dispositiu Google Home.",
       "name": "Reinicia dispositiu"
+    },
+    "refresh_devices": {
+      "description": "Actualitza l'estat de tots els dispositius Google Home.",
+      "name": "Actualitzar dispositius"
     }
   }
 }

--- a/custom_components/google_home/translations/da.json
+++ b/custom_components/google_home/translations/da.json
@@ -36,6 +36,10 @@
           "description": "ID på en alarm (alarm/xxx).",
           "name": "Alarm-ID"
         },
+        "skip_refresh": {
+          "description": "Spring over at opdatere Google Home-enheder efter sletning af en alarm.",
+          "name": "Spring opdatering over"
+        },
         "entity_id": {
           "description": "Repræsenterer en Google Home-enhed (sensor.xxxx_alarms).",
           "name": "Entitet"
@@ -50,6 +54,10 @@
           "description": "ID på en timer (timer/xxx).",
           "name": "Timer-ID"
         },
+        "skip_refresh": {
+          "description": "Spring over at opdatere Google Home-enheder efter sletning af en timer.",
+          "name": "Spring opdatering over"
+        },
         "entity_id": {
           "description": "Repræsenterer en Google Home-enhed (sensor.xxxx_alarms).",
           "name": "Entitet"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Genstart en Google Home-enhed.",
       "name": "Genstart enhed"
+    },
+    "refresh_devices": {
+      "description": "Opdater status for alle Google Home-enheder.",
+      "name": "Opdater enheder"
     }
   }
 }

--- a/custom_components/google_home/translations/de.json
+++ b/custom_components/google_home/translations/de.json
@@ -37,6 +37,10 @@
           "description": "ID eines Alarms (alarm/xxx).",
           "name": "Alarm-ID"
         },
+        "skip_refresh": {
+          "description": "Überspringen Sie die Aktualisierung von Google Home-Geräten nach dem Löschen eines Alarms.",
+          "name": "Aktualisierung überspringen"
+        },
         "entity_id": {
           "description": "Stellt ein Google Home Gerät dar (sensor.xxxx_alarms).",
           "name": "Entität"
@@ -51,6 +55,10 @@
           "description": "ID eines Timers (timer/xxx).",
           "name": "Timer-ID"
         },
+        "skip_refresh": {
+          "description": "Überspringen Sie die Aktualisierung von Google Home-Geräten, nachdem Sie einen Timer gelöscht haben.",
+          "name": "Aktualisierung überspringen"
+        },
         "entity_id": {
           "description": "Stellt ein Google Home Gerät dar (sensor.xxxx_alarms).",
           "name": "Entität"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Ein Google Home Gerät neu starten.",
       "name": "Gerät neu starten"
+    },
+    "refresh_devices": {
+      "description": "Aktualisieren Sie den Status aller Google Home-Geräte.",
+      "name": "Geräte aktualisieren"
     }
   }
 }

--- a/custom_components/google_home/translations/en.json
+++ b/custom_components/google_home/translations/en.json
@@ -38,9 +38,9 @@
           "description": "ID of an alarm (alarm/xxx).",
           "name": "Alarm ID"
         },
-        "force_refresh": {
-          "description": "Force refreshing Google Home devices after deleting the alarm.",
-          "name": "Force Refresh"
+        "skip_refresh": {
+          "description": "Skip refreshing Google Home devices after deleting an alarm.",
+          "name": "Skip refresh"
         },
         "entity_id": {
           "description": "Represents a Google Home device (sensor.xxxx_alarms).",
@@ -56,9 +56,9 @@
           "description": "ID of a timer (timer/xxx).",
           "name": "Timer ID"
         },
-        "force_refresh": {
-          "description": "Force refreshing Google Home devices after deleting the timer.",
-          "name": "Force Refresh"
+        "skip_refresh": {
+          "description": "Skip refreshing Google Home devices after deleting a timer.",
+          "name": "Skip refresh"
         },
         "entity_id": {
           "description": "Represents a Google Home device (sensor.xxxx_alarms).",

--- a/custom_components/google_home/translations/en.json
+++ b/custom_components/google_home/translations/en.json
@@ -38,6 +38,10 @@
           "description": "ID of an alarm (alarm/xxx).",
           "name": "Alarm ID"
         },
+        "force_refresh": {
+          "description": "Force refreshing Google Home devices after deleting the alarm.",
+          "name": "Force Refresh"
+        },
         "entity_id": {
           "description": "Represents a Google Home device (sensor.xxxx_alarms).",
           "name": "Entity"
@@ -52,6 +56,10 @@
           "description": "ID of a timer (timer/xxx).",
           "name": "Timer ID"
         },
+        "force_refresh": {
+          "description": "Force refreshing Google Home devices after deleting the timer.",
+          "name": "Force Refresh"
+        },
         "entity_id": {
           "description": "Represents a Google Home device (sensor.xxxx_alarms).",
           "name": "Entity"
@@ -62,6 +70,10 @@
     "reboot_device": {
       "description": "Reboot a Google Home device.",
       "name": "Reboot device"
+    },
+    "refresh_devices": {
+      "description": "Refresh the status of all Google Home Devices.",
+      "name": "Refresh devices"
     }
   }
 }

--- a/custom_components/google_home/translations/es.json
+++ b/custom_components/google_home/translations/es.json
@@ -37,6 +37,10 @@
           "description": "ID de una alarma (alarm/xxx).",
           "name": "ID de alarma"
         },
+        "skip_refresh": {
+          "description": "Omita la actualización de los dispositivos Google Home después de eliminar una alarma.",
+          "name": "Saltar actualización"
+        },
         "entity_id": {
           "description": "Representa un dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidad"
@@ -51,6 +55,10 @@
           "description": "ID de un temporizador (timer/xxx).",
           "name": "ID de temporizador"
         },
+        "skip_refresh": {
+          "description": "Omita la actualización de los dispositivos Google Home después de eliminar un temporizador.",
+          "name": "Saltar actualización"
+        },
         "entity_id": {
           "description": "Representa un dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidad"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Reiniciar un dispositivo Google Home.",
       "name": "Reiniciar dispositivo"
+    },
+    "refresh_devices": {
+      "description": "Actualiza el estado de todos los dispositivos Google Home.",
+      "name": "Actualizar dispositivos"
     }
   }
 }

--- a/custom_components/google_home/translations/fr.json
+++ b/custom_components/google_home/translations/fr.json
@@ -37,6 +37,10 @@
           "description": "ID d'un réveil (alarm/xxx).",
           "name": "ID de l'alarme"
         },
+        "skip_refresh": {
+          "description": "Ignorez l'actualisation des appareils Google Home après la suppression d'une alarme.",
+          "name": "Ignorer l'actualisation"
+        },
         "entity_id": {
           "description": "Représente un appareil Google Home (sensor.xxxx_alarms).",
           "name": "Entité"
@@ -51,6 +55,10 @@
           "description": "ID d'un minuteur (timer/xxx).",
           "name": "ID du minuteur"
         },
+        "skip_refresh": {
+          "description": "Ignorez l'actualisation des appareils Google Home après la suppression d'une minuterie.",
+          "name": "Ignorer l'actualisation"
+        },
         "entity_id": {
           "description": "Représente un appareil Google Home (sensor.xxxx_alarms).",
           "name": "Entité"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Redémarrer un appareil Google Home.",
       "name": "Redémarrer l'appareil"
+    },
+    "refresh_devices": {
+      "description": "Actualisez l'état de tous les appareils Google Home.",
+      "name": "Actualiser les appareils"
     }
   }
 }

--- a/custom_components/google_home/translations/it.json
+++ b/custom_components/google_home/translations/it.json
@@ -36,6 +36,10 @@
           "description": "ID di una sveglia (alarm/xxx).",
           "name": "ID Sveglia"
         },
+        "skip_refresh": {
+          "description": "Salta l'aggiornamento dei dispositivi Google Home dopo aver eliminato una sveglia.",
+          "name": "Salta aggiornamento"
+        },
         "entity_id": {
           "description": "Rappresenta un dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entità"
@@ -50,6 +54,10 @@
           "description": "ID di un timer (timer/xxx).",
           "name": "ID Timer"
         },
+        "skip_refresh": {
+          "description": "Salta l'aggiornamento dei dispositivi Google Home dopo aver eliminato un timer.",
+          "name": "Salta aggiornamento"
+        },
         "entity_id": {
           "description": "Rappresenta un dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entità"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Riavvia un dispositivo Google Home.",
       "name": "Riavvia dispositivo"
+    },
+    "refresh_devices": {
+      "description": "Aggiorna lo stato di tutti i dispositivi Google Home.",
+      "name": "Aggiorna i dispositivi"
     }
   }
 }

--- a/custom_components/google_home/translations/nb.json
+++ b/custom_components/google_home/translations/nb.json
@@ -36,6 +36,10 @@
           "description": "ID for en alarm (alarm/xxx).",
           "name": "Alarm-ID"
         },
+        "skip_refresh": {
+          "description": "Hopp over oppdatering av Google Home-enheter etter at du har slettet en alarm.",
+          "name": "Hopp over oppdatering"
+        },
         "entity_id": {
           "description": "Representerer en Google Home-enhet (sensor.xxxx_alarms).",
           "name": "Entitet"
@@ -50,6 +54,10 @@
           "description": "ID for en timer (timer/xxx).",
           "name": "Timer-ID"
         },
+        "skip_refresh": {
+          "description": "Hopp over oppdatering av Google Home-enheter etter at du har slettet en timer.",
+          "name": "Hopp over oppdatering"
+        },
         "entity_id": {
           "description": "Representerer en Google Home-enhet (sensor.xxxx_alarms).",
           "name": "Entitet"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Start en Google Home-enhet på nytt.",
       "name": "Start enhet på nytt"
+    },
+    "refresh_devices": {
+      "description": "Oppdater statusen til alle Google Home-enheter.",
+      "name": "Oppdater enheter"
     }
   }
 }

--- a/custom_components/google_home/translations/nl.json
+++ b/custom_components/google_home/translations/nl.json
@@ -36,6 +36,10 @@
           "description": "ID van een alarm (alarm/xxx).",
           "name": "Alarm-ID"
         },
+        "skip_refresh": {
+          "description": "Sla het verversen van Google Home-apparaten over na het verwijderen van een alarm.",
+          "name": "Verversen overslaan"
+        },
         "entity_id": {
           "description": "Vertegenwoordigt een Google Home-apparaat (sensor.xxxx_alarms).",
           "name": "Entiteit"
@@ -50,6 +54,10 @@
           "description": "ID van een timer (timer/xxx).",
           "name": "Timer-ID"
         },
+        "skip_refresh": {
+          "description": "Sla het verversen van Google Home-apparaten over na het verwijderen van een timer.",
+          "name": "Verversen overslaan"
+        },
         "entity_id": {
           "description": "Vertegenwoordigt een Google Home-apparaat (sensor.xxxx_alarms).",
           "name": "Entiteit"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Herstart een Google Home-apparaat.",
       "name": "Apparaat herstarten"
+    },
+    "refresh_devices": {
+      "description": "De status van alle Google Home-apparaten verversen.",
+      "name": "Apparaten verversen"
     }
   }
 }

--- a/custom_components/google_home/translations/nn.json
+++ b/custom_components/google_home/translations/nn.json
@@ -36,6 +36,10 @@
           "description": "ID for ein alarm (alarm/xxx).",
           "name": "Alarm-ID"
         },
+        "skip_refresh": {
+          "description": "Hopp over oppdatering av Google heimeseiningar etter å sletta ein alarm.",
+          "name": "Hopp over oppdatering"
+        },
         "entity_id": {
           "description": "Representerar ei Google Home-eining (sensor.xxxx_alarms).",
           "name": "Eining"
@@ -50,6 +54,10 @@
           "description": "ID for ein tidtakar (timer/xxx).",
           "name": "Tidtakar-ID"
         },
+        "skip_refresh": {
+          "description": "Hopp over oppdatering av Google heimeseiningar etter å sletta ein tidsaverk.",
+          "name": "Hopp over oppdatering"
+        },
         "entity_id": {
           "description": "Representerar ei Google Home-eining (sensor.xxxx_alarms).",
           "name": "Eining"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Start ei Google Home-eining på nytt.",
       "name": "Start eining på nytt"
+    },
+    "refresh_devices": {
+      "description": "Oppdater statusen til alle Google heimeseiningar.",
+      "name": "Oppdater einingar"
     }
   }
 }

--- a/custom_components/google_home/translations/pl.json
+++ b/custom_components/google_home/translations/pl.json
@@ -37,6 +37,10 @@
           "description": "ID alarmu (alarm/xxx).",
           "name": "ID alarmu"
         },
+        "skip_refresh": {
+          "description": "Pomiń odświeżanie urządzeń Google Home po usunięciu alarmu.",
+          "name": "Pomiń odświeżanie"
+        },
         "entity_id": {
           "description": "Reprezentuje urządzenie Google Home (sensor.xxxx_alarms).",
           "name": "Encja"
@@ -51,6 +55,10 @@
           "description": "ID timera (timer/xxx).",
           "name": "ID timera"
         },
+        "skip_refresh": {
+          "description": "Pomija odświeżanie urządzeń Google Home po usunięciu timera.",
+          "name": "Pomiń odświeżanie"
+        },
         "entity_id": {
           "description": "Reprezentuje urządzenie Google Home (sensor.xxxx_alarms).",
           "name": "Encja"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Uruchom ponownie urządzenie Google Home.",
       "name": "Uruchom ponownie urządzenie"
+    },
+    "refresh_devices": {
+      "description": "Odśwież stan wszystkich urządzeń Google Home.",
+      "name": "Odśwież urządzenia"
     }
   }
 }

--- a/custom_components/google_home/translations/pt-BR.json
+++ b/custom_components/google_home/translations/pt-BR.json
@@ -37,6 +37,10 @@
           "description": "ID do alarme (alarm/xxx).",
           "name": "ID do alarme"
         },
+        "skip_refresh": {
+          "description": "Ignorar a atualização dos dispositivos Google Home após a exclusão de um alarme.",
+          "name": "Ignorar atualização"
+        },
         "entity_id": {
           "description": "Representa um dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidade"
@@ -51,6 +55,10 @@
           "description": "ID do temporizador (timer/xxx).",
           "name": "ID do temporizador"
         },
+        "skip_refresh": {
+          "description": "Ignorar a atualização dos dispositivos Google Home após a exclusão de um cronômetro.",
+          "name": "Ignorar atualização"
+        },
         "entity_id": {
           "description": "Representa um dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidade"
@@ -61,6 +69,10 @@
     "reboot_device": {
       "description": "Reiniciar um dispositivo Google Home.",
       "name": "Reiniciar dispositivo"
+    },
+    "refresh_devices": {
+      "description": "Atualizar o status de todos os dispositivos Google Home.",
+      "name": "Atualizar dispositivos"
     }
   }
 }

--- a/custom_components/google_home/translations/pt.json
+++ b/custom_components/google_home/translations/pt.json
@@ -36,6 +36,10 @@
           "description": "ID do alarme (alarm/xxx).",
           "name": "ID do alarme"
         },
+        "skip_refresh": {
+          "description": "Ignorar a atualização dos dispositivos Google Home depois de eliminar um alarme.",
+          "name": "Ignorar atualização"
+        },
         "entity_id": {
           "description": "Representa um dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidade"
@@ -50,6 +54,10 @@
           "description": "ID do temporizador (timer/xxx).",
           "name": "ID do temporizador"
         },
+        "skip_refresh": {
+          "description": "Ignorar a atualização dos dispositivos Google Home depois de eliminar um temporizador.",
+          "name": "Ignorar atualização"
+        },
         "entity_id": {
           "description": "Representa um dispositivo Google Home (sensor.xxxx_alarms).",
           "name": "Entidade"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Reiniciar um dispositivo Google Home.",
       "name": "Reiniciar dispositivo"
+    },
+    "refresh_devices": {
+      "description": "Atualizar o estado de todos os dispositivos Google Home.",
+      "name": "Atualizar dispositivos"
     }
   }
 }

--- a/custom_components/google_home/translations/ru.json
+++ b/custom_components/google_home/translations/ru.json
@@ -36,6 +36,10 @@
           "description": "Идентификатор будильника (alarm/xxx).",
           "name": "Идентификатор будильника"
         },
+        "skip_refresh": {
+          "description": "Пропустить обновление устройств Google Home после удаления будильника.",
+          "name": "Пропустить обновление"
+        },
         "entity_id": {
           "description": "Представляет устройство Google Home (sensor.xxxx_alarms).",
           "name": "Объект"
@@ -50,6 +54,10 @@
           "description": "Идентификатор таймера (timer/xxx).",
           "name": "Идентификатор таймера"
         },
+        "skip_refresh": {
+          "description": "Пропустить обновление устройств Google Home после удаления таймера.",
+          "name": "Пропустить обновление"
+        },
         "entity_id": {
           "description": "Представляет устройство Google Home (sensor.xxxx_alarms).",
           "name": "Объект"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Перезагрузить устройство Google Home.",
       "name": "Перезагрузить устройство"
+    },
+    "refresh_devices": {
+      "description": "Обновить состояние всех устройств Google Home.",
+      "name": "Обновить устройства"
     }
   }
 }

--- a/custom_components/google_home/translations/sk.json
+++ b/custom_components/google_home/translations/sk.json
@@ -38,6 +38,10 @@
           "description": "ID budíka (alarm/xxx).",
           "name": "ID budíka"
         },
+        "skip_refresh": {
+          "description": "Vynechanie obnovenia zariadení Google Home po vymazaní budíka.",
+          "name": "Preskočiť obnovenie"
+        },
         "entity_id": {
           "description": "Reprezentuje zariadenie Google Home (sensor.xxxx_alarms).",
           "name": "Entita"
@@ -52,6 +56,10 @@
           "description": "ID časovača (timer/xxx).",
           "name": "ID časovača"
         },
+        "skip_refresh": {
+          "description": "Vynechanie obnovenia zariadení Google Home po vymazaní časovača.",
+          "name": "Preskočiť obnovenie"
+        },
         "entity_id": {
           "description": "Reprezentuje zariadenie Google Home (sensor.xxxx_alarms).",
           "name": "Entita"
@@ -62,6 +70,10 @@
     "reboot_device": {
       "description": "Reštartovať zariadenie Google Home.",
       "name": "Reštartovať zariadenie"
+    },
+    "refresh_devices": {
+      "description": "Obnoviť stav všetkých zariadení Google Home.",
+      "name": "Obnoviť zariadenia"
     }
   }
 }

--- a/custom_components/google_home/translations/uk.json
+++ b/custom_components/google_home/translations/uk.json
@@ -36,6 +36,10 @@
           "description": "ID будильника (alarm/xxx).",
           "name": "ID будильника"
         },
+        "skip_refresh": {
+          "description": "Пропустити оновлення пристроїв Google Home після видалення будильника.",
+          "name": "Пропустити оновлення"
+        },
         "entity_id": {
           "description": "Представляє пристрій Google Home (sensor.xxxx_alarms).",
           "name": "Сутність"
@@ -50,6 +54,10 @@
           "description": "ID таймера (timer/xxx).",
           "name": "ID таймера"
         },
+        "skip_refresh": {
+          "description": "Пропустити оновлення пристроїв Google Home після видалення таймера.",
+          "name": "Пропустити оновлення"
+        },
         "entity_id": {
           "description": "Представляє пристрій Google Home (sensor.xxxx_alarms).",
           "name": "Сутність"
@@ -60,6 +68,10 @@
     "reboot_device": {
       "description": "Перезавантажити пристрій Google Home.",
       "name": "Перезавантажити пристрій"
+    },
+    "refresh_devices": {
+      "description": "Оновити стан усіх пристроїв Google Home.",
+      "name": "Оновити пристрої"
     }
   }
 }


### PR DESCRIPTION
- Add an optional `force_refresh` parameter to `delete_timers` and `delete_alarms`
- Add a `refresh_devices` service to allow manual refreshes

Both options invoke `async_request_refresh` on the coordinator and therefore restart the refresh timer to prevent over-requesting devices. They provide a reasonable (and optional) method to immediately update devices when deleted, or to allow users to refresh timers/alarms.