### PR TITLE
Use none as sensor state when no alarm or timer is set

### DIFF
--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -281,11 +281,7 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
         if not device:
             return None
         timer = device.get_next_timer()
-        return (
-            timer.local_time_iso
-            if timer and timer.local_time_iso
-            else None
-        )
+        return timer.local_time_iso if timer and timer.local_time_iso else None
 
     @property
     def extra_state_attributes(self) -> TimersAttributes:

--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity, EntityCategory
@@ -202,7 +201,7 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             if next_alarm
             and next_alarm.status
             not in (GoogleHomeAlarmStatus.INACTIVE, GoogleHomeAlarmStatus.MISSED)
-            else STATE_UNAVAILABLE
+            else None
         )
 
     @property
@@ -285,7 +284,7 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
         return (
             timer.local_time_iso
             if timer and timer.local_time_iso
-            else STATE_UNAVAILABLE
+            else None
         )
 
     @property


### PR DESCRIPTION
This PR introduces a small change to the alarm and timer sensor entities. When no alarm or timer is set, the entity returns its state as `None` instead of `"unavailable"`. This will display a localized string "Unknown" in the UI instead of marking the entity as unavailable. This still does not reflect the actual state, since it is indeed known that no alarms or timers are set, but should be a temporary improvement over having the entity marked as unavailable which usually indicates to the user that there is some kind of problem, which is not the case here.

Closes #278