### PR TITLE
Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
       interval: daily
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "crazy-max/ghaction-github-labeler"
+        versions: ["5.1.0"]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,6 +4,10 @@
 #
 # The repository labels will be automatically configured using this file and
 # the GitHub Action https://github.com/marketplace/actions/github-labeler.
+- name: automerge
+  description: Automatically merge by Kodiak
+  color: d4c5f9
+
 - name: bug
   description: Something isn't working
   color: d73a4a

--- a/.github/workflows/home-assistant.yml
+++ b/.github/workflows/home-assistant.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  DEFAULT_PYTHON: "3.11"
+  DEFAULT_PYTHON: "3.12"
 
 jobs:
   hacs:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   pre-commit:

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -14,4 +14,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   publish:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -26,16 +26,19 @@ repos:
         entry: poetry run mypy
         language: system
         types: [python]
+        require_serial: true
       - id: flake8
         name: flake8
         entry: poetry run flake8
         language: system
         types: [python]
+        require_serial: true
       - id: pylint
         name: pylint
         entry: poetry run pylint
         language: system
         types: [python]
+        require_serial: true
       - id: codespell
         name: codespell
         entry: poetry run codespell --write-changes
@@ -43,12 +46,12 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.1.0
     hooks:
       - id: prettier
         exclude: ^custom_components/google_home/manifest\.json$
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.5.1
+    rev: v0.7.0
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.


### PR DESCRIPTION
- Run CI on Python 3.12 as it's minimum for `homeassistant` now.
- Add `automerge` label for Kodiak.
- Downgrade `crazy-max/ghaction-github-labeler` and prevent dependabot from updating it. Current version is broken.
- Update `pre-commit` hooks.