### PR TITLE
Rename config_entry to _config_entry

### DIFF
--- a/custom_components/google_home/config_flow.py
+++ b/custom_components/google_home/config_flow.py
@@ -156,7 +156,7 @@ class GoogleHomeOptionsFlowHandler(OptionsFlow):
 
     def __init__(self, config_entry: GoogleHomeConfigEntry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         # Cast from MappingProxy to dict to allow update.
         self.options = dict(config_entry.options)
 


### PR DESCRIPTION
Fix error 500 when I click on configuration :
<img width="1102" height="255" alt="image" src="https://github.com/user-attachments/assets/a9d1b570-ca20-4b48-b456-a6412e328307" />

<img width="584" height="339" alt="image" src="https://github.com/user-attachments/assets/5898efd4-1f1a-426b-bdad-c9203fdc95f7" />


