### PR TITLE
Explicitly pass config_entry to DataUpdateCoordinator

### DIFF
--- a/custom_components/google_home/__init__.py
+++ b/custom_components/google_home/__init__.py
@@ -72,6 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoogleHomeConfigEntry) -
         name=SENSOR,
         update_method=glocaltokens_client.update_google_devices_information,
         update_interval=timedelta(seconds=update_interval),
+        config_entry=entry,
     )
 
     await coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
Fix warning `Detected code that relies on ContextVar, but should pass the config entry explicitly. This will stop working in Home Assistant 2026.8`.

Fixes #1006 