### PR TITLE
Fix delete service skip_refresh default handling

### DIFF
--- a/custom_components/google_home/sensor.py
+++ b/custom_components/google_home/sensor.py
@@ -267,14 +267,14 @@ class GoogleHomeAlarmsSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=alarm_id)
-        if not call.data[SERVICE_ATTR_SKIP_REFRESH]:
+        if not call.data.get(SERVICE_ATTR_SKIP_REFRESH, False):
             await self.coordinator.async_request_refresh()
 
 
 class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
     """Google Home Timers sensor."""
 
-    _attr_icons = ICON_TIMERS
+    _attr_icon = ICON_TIMERS
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
     @property
@@ -344,6 +344,6 @@ class GoogleHomeTimersSensor(GoogleHomeBaseEntity):
             return
 
         await self.client.delete_alarm_or_timer(device=device, item_to_delete=timer_id)
-        if not call.data[SERVICE_ATTR_SKIP_REFRESH]:
+        if not call.data.get(SERVICE_ATTR_SKIP_REFRESH, False):
             _LOGGER.debug("Refreshing Devices")
             await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Fixes delete_alarm and delete_timer service calls when skip_refresh is omitted.

The service schema marks skip_refresh as optional, but the handlers accessed it directly from call.data, which can raise KeyError. The handlers now default to False when the field is not provided.

Also fixes the timer sensor icon attribute typo.