### PR TITLE
Keep unavailable devices in coordinator data

### DIFF
--- a/custom_components/google_home/api.py
+++ b/custom_components/google_home/api.py
@@ -157,13 +157,15 @@ class GlocaltokensApiClient:
                     device.name,
                 )
 
-        return await asyncio.gather(
+        await asyncio.gather(
             *[
                 self.collect_data_from_endpoints(device)
                 for device in devices
                 if device.ip_address and device.auth_token
             ]
         )
+
+        return devices
 
     async def collect_data_from_endpoints(
         self, device: GoogleHomeDevice


### PR DESCRIPTION
Keep unavailable Google Home devices in coordinator data.

The update method marked devices without an IP address as unavailable, but then returned only devices with both an IP address and auth token. This caused unavailable or unsupported devices to disappear from coordinator data instead of being exposed as unavailable.

The coordinator now polls only reachable devices, but returns the full device list.